### PR TITLE
Use default path for images service

### DIFF
--- a/Sources/SRGDataProviderRequests/SRGDataProvider+ImageURLs.m
+++ b/Sources/SRGDataProviderRequests/SRGDataProvider+ImageURLs.m
@@ -80,9 +80,13 @@
         };
     });
     
-    NSURL *URL = [self.serviceURL URLByAppendingPathComponent:@"images/"];
-    NSURLComponents *URLComponents = [NSURLComponents componentsWithURL:URL resolvingAgainstBaseURL:NO];
+    NSURLComponents *rootServiceURLComponents = [[NSURLComponents alloc] init];
+    rootServiceURLComponents.scheme = self.serviceURL.scheme;
+    rootServiceURLComponents.host = self.serviceURL.host;
     
+    NSURL *URL = [rootServiceURLComponents.URL URLByAppendingPathComponent:@"images/"];
+    NSURLComponents *URLComponents = [NSURLComponents componentsWithURL:URL resolvingAgainstBaseURL:NO];
+
     NSString *format = s_formats[imageURL.pathExtension] ?: @"jpg";
     URLComponents.queryItems = @[
         [NSURLQueryItem queryItemWithName:@"imageUrl" value:imageURL.absoluteString],


### PR DESCRIPTION
The `images` services is not part of the `integration layer` service.
The new `SAM` service is only for a future `integration layer` service replacement.

In this case, the `images` should not follow sub paths and stay at the root of the domain.