### PR TITLE
Avoid type erasure need in accumulation publishers

### DIFF
--- a/Sources/SRGDataProviderCombine/Publishers.swift
+++ b/Sources/SRGDataProviderCombine/Publishers.swift
@@ -78,23 +78,23 @@ public extension Publishers {
     }
     
     /**
-     *  Accumulate the latest values emitted by several publishers into an array. All the publishers must emit a
-     *  value before `AccumulateLatestMany` emits a value, as for `CombineLatest`.
+     *  Accumulate the results of a list of publishers and deliver them as a stream of arrays containing the latest
+     *  values in publisher order. The first array is emitted once all publishers have at least emitted a value once.
      */
-    static func AccumulateLatestMany<Output, Failure>(_ publishers: AnyPublisher<Output, Failure>...) -> AnyPublisher<[Output], Failure> {
+    static func AccumulateLatestMany<Upstream>(_ publishers: Upstream...) -> AnyPublisher<[Upstream.Output], Upstream.Failure> where Upstream: Publisher {
         return AccumulateLatestMany(publishers)
     }
     
     /**
-     *  Accumulate the latest values emitted by a sequence of publishers into an array. All the publishers must
-     *  emit a value before `AccumulateLatestMany` emits a value, as for `CombineLatest`.
+     *  Accumulate the results of a list of publishers and deliver them as a stream of arrays containing the latest
+     *  values in publisher order. The first array is emitted once all publishers have at least emitted a value once.
      */
-    static func AccumulateLatestMany<S, Output, Failure>(_ publishers: S) -> AnyPublisher<[Output], Failure> where S: Swift.Sequence, S.Element == AnyPublisher<Output, Failure> {
+    static func AccumulateLatestMany<Upstream, S>(_ publishers: S) -> AnyPublisher<[Upstream.Output], Upstream.Failure> where Upstream: Publisher, S: Swift.Sequence, S.Element == Upstream {
         let publishersArray = Array(publishers)
         switch publishersArray.count {
         case 0:
             return Just([])
-                .setFailureType(to: Failure.self)
+                .setFailureType(to: Upstream.Failure.self)
                 .eraseToAnyPublisher()
         case 1:
             return publishersArray[0]

--- a/Tests/SRGDataProviderCombineTests/PublishersTestCase.swift
+++ b/Tests/SRGDataProviderCombineTests/PublishersTestCase.swift
@@ -1,0 +1,36 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import SRGDataProviderCombine
+import XCTest
+
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class PublishersTestCase: XCTestCase {
+    private var cancellables = Set<AnyCancellable>()
+
+    override func tearDown() {
+        super.tearDown()
+        cancellables = []
+    }
+
+    func testSyntaxWithoutTypeErasure() {
+        let expectation = expectation(description: "Publisher completed")
+
+        Publishers.AccumulateLatestMany(
+            Just(1),
+            Just(2),
+            Just(3)
+        )
+        .sink { completion in
+            expectation.fulfill()
+        } receiveValue: { value in
+            XCTAssertEqual(value, [1, 2, 3])
+        }
+        .store(in: &cancellables)
+
+        waitForExpectations(timeout: 2)
+    }
+}

--- a/Tests/SRGDataProviderCombineTests/RequestsTestCase.swift
+++ b/Tests/SRGDataProviderCombineTests/RequestsTestCase.swift
@@ -12,7 +12,7 @@ enum TestError: Error {
 }
 
 @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-final class DataProviderCombineTestCase: XCTestCase {
+final class RequestsTestCase: XCTestCase {
     var dataProvider: SRGDataProvider!
     var cancellables: Set<AnyCancellable>!
     
@@ -104,6 +104,4 @@ final class DataProviderCombineTestCase: XCTestCase {
         
         waitForExpectations(timeout: 10.0, handler: nil)
     }
-    
-    // TODO: Should test Triggers and associated publisher operators
 }


### PR DESCRIPTION
# Pull request

## Description

This PR improves `Publishers.AccumulateLatestMany` signature so that it can be used without type erasure.

## Changes made

- Add a UT validating prototype changes (the content of the UT is itself not that relevant and barely tests `Publishers.AccumulateLatestMany` behavior).
- Update method prototypes.

This accumulator publisher is now also part of [Pillarbox](https://github.com/SRGSSR/pillarbox-apple) `Core` package. I thoroughly tested its behavior there and I propose to backport prototype improvements to SRG Data Provider in the meantime.

Publisher testing support is far better in Pillarbox. For this reason I decided not to add other tests which are made in Pillarbox.
