### PR TITLE
Remove legacy image scaling options

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -77,6 +77,10 @@ let package = Package(
             ]
         ),
         .testTarget(
+            name: "SRGDataProviderRequestsTests",
+            dependencies: ["SRGDataProviderRequests"]
+        ),
+        .testTarget(
             name: "SRGDataProviderNetworkTests",
             dependencies: ["SRGDataProviderNetwork"]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 
 struct ProjectSettings {
-    static let marketingVersion: String = "17.0.2"
+    static let marketingVersion: String = "18.0.0"
 }
 
 let package = Package(

--- a/Sources/SRGDataProviderCombine/ImageServices.swift
+++ b/Sources/SRGDataProviderCombine/ImageServices.swift
@@ -9,14 +9,14 @@
  */
 public extension SRGDataProvider {
     /**
-     *  Return the URL for an image having a given width and scaled by applying the specified behavior.
+     *  Return the URL for an image having a given width and scaling service by applying the specified behavior.
      */
     func url(for image: SRGImage?, width: SRGImageWidth, scalingService: SRGImageScalingService = .default) -> URL? {
         return requestURL(for: image, with: width, scalingService: scalingService)
     }
     
     /**
-     *  Return the URL for an image having a given semantic size and scaled by applying the specified behavior.
+     *  Return the URL for an image having a given semantic size and scaling service by applying the specified behavior.
      */
     func url(for image: SRGImage?, size: SRGImageSize, scalingService: SRGImageScalingService = .default) -> URL? {
         return requestURL(for: image, with: size, scalingService: scalingService)

--- a/Sources/SRGDataProviderCombine/ImageServices.swift
+++ b/Sources/SRGDataProviderCombine/ImageServices.swift
@@ -11,14 +11,14 @@ public extension SRGDataProvider {
     /**
      *  Return the URL for an image having a given width and scaling service by applying the specified behavior.
      */
-    func url(for image: SRGImage?, width: SRGImageWidth, scalingService: SRGImageScalingService = .default) -> URL? {
+    func url(for image: SRGImage?, width: SRGImageWidth, scalingService: SRGImageScalingService = .businessUnit) -> URL? {
         return requestURL(for: image, with: width, scalingService: scalingService)
     }
     
     /**
      *  Return the URL for an image having a given semantic size and scaling service by applying the specified behavior.
      */
-    func url(for image: SRGImage?, size: SRGImageSize, scalingService: SRGImageScalingService = .default) -> URL? {
+    func url(for image: SRGImage?, size: SRGImageSize, scalingService: SRGImageScalingService = .businessUnit) -> URL? {
         return requestURL(for: image, with: size, scalingService: scalingService)
     }
 }

--- a/Sources/SRGDataProviderCombine/ImageServices.swift
+++ b/Sources/SRGDataProviderCombine/ImageServices.swift
@@ -9,16 +9,16 @@
  */
 public extension SRGDataProvider {
     /**
-     *  Return the URL for an image having a given width and scaling service by applying the specified behavior.
+     *  Return the URL for an image having a given width.
      */
-    func url(for image: SRGImage?, width: SRGImageWidth, scalingService: SRGImageScalingService = .businessUnit) -> URL? {
-        return requestURL(for: image, with: width, scalingService: scalingService)
+    func url(for image: SRGImage?, width: SRGImageWidth) -> URL? {
+        return requestURL(for: image, with: width)
     }
     
     /**
-     *  Return the URL for an image having a given semantic size and scaling service by applying the specified behavior.
+     *  Return the URL for an image having a given semantic size.
      */
-    func url(for image: SRGImage?, size: SRGImageSize, scalingService: SRGImageScalingService = .businessUnit) -> URL? {
-        return requestURL(for: image, with: size, scalingService: scalingService)
+    func url(for image: SRGImage?, size: SRGImageSize) -> URL? {
+        return requestURL(for: image, with: size)
     }
 }

--- a/Sources/SRGDataProviderCombine/ImageServices.swift
+++ b/Sources/SRGDataProviderCombine/ImageServices.swift
@@ -11,14 +11,14 @@ public extension SRGDataProvider {
     /**
      *  Return the URL for an image having a given width and scaled by applying the specified behavior.
      */
-    func url(for image: SRGImage?, width: SRGImageWidth, scaling: SRGImageScaling = .default) -> URL? {
-        return requestURL(for: image, with: width, scaling: scaling)
+    func url(for image: SRGImage?, width: SRGImageWidth, scalingService: SRGImageScalingService = .default) -> URL? {
+        return requestURL(for: image, with: width, scalingService: scalingService)
     }
     
     /**
      *  Return the URL for an image having a given semantic size and scaled by applying the specified behavior.
      */
-    func url(for image: SRGImage?, size: SRGImageSize, scaling: SRGImageScaling = .default) -> URL? {
-        return requestURL(for: image, with: size, scaling: scaling)
+    func url(for image: SRGImage?, size: SRGImageSize, scalingService: SRGImageScalingService = .default) -> URL? {
+        return requestURL(for: image, with: size, scalingService: scalingService)
     }
 }

--- a/Sources/SRGDataProviderModel/include/SRGTypes.h
+++ b/Sources/SRGDataProviderModel/include/SRGTypes.h
@@ -670,7 +670,7 @@ typedef NS_CLOSED_ENUM(NSInteger, SRGContentProviders) {
 typedef NS_CLOSED_ENUM(NSInteger, SRGImageScalingService) {
     SRGImageScalingServiceBusinessUnit = 0,
     SRGImageScalingServiceDefault = SRGImageScalingServiceBusinessUnit,
-    SRGImageScalingServiceIntegrationLayer
+    SRGImageScalingServiceCentralized
 };
 
 /**

--- a/Sources/SRGDataProviderModel/include/SRGTypes.h
+++ b/Sources/SRGDataProviderModel/include/SRGTypes.h
@@ -665,14 +665,6 @@ typedef NS_CLOSED_ENUM(NSInteger, SRGContentProviders) {
 };
 
 /**
- *  Image scaling services.
- */
-typedef NS_CLOSED_ENUM(NSInteger, SRGImageScalingService) {
-    SRGImageScalingServiceBusinessUnit = 0,
-    SRGImageScalingServiceCentralized
-};
-
-/**
  *  Semantic image sizes.
  */
 typedef NS_CLOSED_ENUM(NSInteger, SRGImageSize) {

--- a/Sources/SRGDataProviderModel/include/SRGTypes.h
+++ b/Sources/SRGDataProviderModel/include/SRGTypes.h
@@ -665,15 +665,12 @@ typedef NS_CLOSED_ENUM(NSInteger, SRGContentProviders) {
 };
 
 /**
- *  Image scalings.
+ *  Image scaling services.
  */
-typedef NS_CLOSED_ENUM(NSInteger, SRGImageScaling) {
-    SRGImageScalingAspectFillSixteenToNine = 0,
-    SRGImageScalingDefault = SRGImageScalingAspectFillSixteenToNine,
-    SRGImageScalingAspectFitSixteenToNine,
-    SRGImageScalingAspectFitBlackSquare,
-    SRGImageScalingAspectFitTransparentSquare,
-    SRGImageScalingPreserveAspectRatio
+typedef NS_CLOSED_ENUM(NSInteger, SRGImageScalingService) {
+    SRGImageScalingServiceBusinessUnit = 0,
+    SRGImageScalingServiceDefault = SRGImageScalingServiceBusinessUnit,
+    SRGImageScalingServiceIntegrationLayer
 };
 
 /**

--- a/Sources/SRGDataProviderModel/include/SRGTypes.h
+++ b/Sources/SRGDataProviderModel/include/SRGTypes.h
@@ -669,7 +669,6 @@ typedef NS_CLOSED_ENUM(NSInteger, SRGContentProviders) {
  */
 typedef NS_CLOSED_ENUM(NSInteger, SRGImageScalingService) {
     SRGImageScalingServiceBusinessUnit = 0,
-    SRGImageScalingServiceDefault = SRGImageScalingServiceBusinessUnit,
     SRGImageScalingServiceCentralized
 };
 

--- a/Sources/SRGDataProviderNetwork/SRGDataProvider+ImageServices.m
+++ b/Sources/SRGDataProviderNetwork/SRGDataProvider+ImageServices.m
@@ -12,14 +12,14 @@
 
 #pragma mark Public methods
 
-- (NSURL *)URLForImage:(SRGImage *)image withWidth:(SRGImageWidth)width scaling:(SRGImageScaling)scaling
+- (NSURL *)URLForImage:(SRGImage *)image withWidth:(SRGImageWidth)width scalingService:(SRGImageScalingService)scalingService
 {
-    return [self requestURLForImage:image withWidth:width scaling:scaling];
+    return [self requestURLForImage:image withWidth:width scalingService:scalingService];
 }
 
-- (NSURL *)URLForImage:(SRGImage *)image withSize:(SRGImageSize)size scaling:(SRGImageScaling)scaling
+- (NSURL *)URLForImage:(SRGImage *)image withSize:(SRGImageSize)size scalingService:(SRGImageScalingService)scalingService
 {
-    return [self requestURLForImage:image withSize:size scaling:scaling];
+    return [self requestURLForImage:image withSize:size scalingService:scalingService];
 }
 
 @end

--- a/Sources/SRGDataProviderNetwork/SRGDataProvider+ImageServices.m
+++ b/Sources/SRGDataProviderNetwork/SRGDataProvider+ImageServices.m
@@ -12,14 +12,14 @@
 
 #pragma mark Public methods
 
-- (NSURL *)URLForImage:(SRGImage *)image withWidth:(SRGImageWidth)width scalingService:(SRGImageScalingService)scalingService
+- (NSURL *)URLForImage:(SRGImage *)image withWidth:(SRGImageWidth)width
 {
-    return [self requestURLForImage:image withWidth:width scalingService:scalingService];
+    return [self requestURLForImage:image withWidth:width];
 }
 
-- (NSURL *)URLForImage:(SRGImage *)image withSize:(SRGImageSize)size scalingService:(SRGImageScalingService)scalingService
+- (NSURL *)URLForImage:(SRGImage *)image withSize:(SRGImageSize)size
 {
-    return [self requestURLForImage:image withSize:size scalingService:scalingService];
+    return [self requestURLForImage:image withSize:size];
 }
 
 @end

--- a/Sources/SRGDataProviderNetwork/include/SRGDataProvider+ImageServices.h
+++ b/Sources/SRGDataProviderNetwork/include/SRGDataProvider+ImageServices.h
@@ -13,14 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SRGDataProvider (ImageServices)
 
 /**
- *  Return the URL for an image having a given width and scaled by applying the specified behavior.
+ *  Return the URL for an image having a given width.
  */
-- (nullable NSURL *)URLForImage:(nullable SRGImage *)image withWidth:(SRGImageWidth)width scalingService:(SRGImageScalingService)scalingService;
+- (nullable NSURL *)URLForImage:(nullable SRGImage *)image withWidth:(SRGImageWidth)width;
 
 /**
- *  Return the URL for an image having a given semantic size and scaled by applying the specified behavior.
+ *  Return the URL for an image having a given semantic size.
  */
-- (nullable NSURL *)URLForImage:(nullable SRGImage *)image withSize:(SRGImageSize)size scalingService:(SRGImageScalingService)scalingService;
+- (nullable NSURL *)URLForImage:(nullable SRGImage *)image withSize:(SRGImageSize)size;
 
 @end
 

--- a/Sources/SRGDataProviderNetwork/include/SRGDataProvider+ImageServices.h
+++ b/Sources/SRGDataProviderNetwork/include/SRGDataProvider+ImageServices.h
@@ -15,12 +15,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Return the URL for an image having a given width and scaled by applying the specified behavior.
  */
-- (nullable NSURL *)URLForImage:(nullable SRGImage *)image withWidth:(SRGImageWidth)width scaling:(SRGImageScaling)scaling;
+- (nullable NSURL *)URLForImage:(nullable SRGImage *)image withWidth:(SRGImageWidth)width scalingService:(SRGImageScalingService)scalingService;
 
 /**
  *  Return the URL for an image having a given semantic size and scaled by applying the specified behavior.
  */
-- (nullable NSURL *)URLForImage:(nullable SRGImage *)image withSize:(SRGImageSize)size scaling:(SRGImageScaling)scaling;
+- (nullable NSURL *)URLForImage:(nullable SRGImage *)image withSize:(SRGImageSize)size scalingService:(SRGImageScalingService)scalingService;
 
 @end
 

--- a/Sources/SRGDataProviderRequests/SRGDataProvider+ImageURLs.m
+++ b/Sources/SRGDataProviderRequests/SRGDataProvider+ImageURLs.m
@@ -33,13 +33,13 @@
     }
     
     switch (scalingService) {
-        case SRGImageScalingServiceIntegrationLayer: {
-            return [self imageServiceURLForImageURL:imageURL width:width];
+        case SRGImageScalingServiceCentralized: {
+            return [self centralizedScalingServiceURLForImageURL:imageURL width:width];
             break;
         }
             
         default: {
-            return [self scaledImageURL:imageURL width:width];
+            return [self businessUnitScalingServiceURLForImageURL:imageURL width:width];
             break;
         }
     }
@@ -50,9 +50,9 @@
     return [self requestURLForImageURL:imageURL withWidth:SRGRecommendedImageWidth(size, variant) scalingService:scalingService];
 }
 
-#pragma mark Modern image scaling
+#pragma mark Centralised image scaling service
 
-- (NSURL *)imageServiceURLForImageURL:(NSURL *)imageURL width:(SRGImageWidth)width
+- (NSURL *)centralizedScalingServiceURLForImageURL:(NSURL *)imageURL width:(SRGImageWidth)width
 {
     static NSDictionary<NSString *, NSString *> *s_formats;
     static dispatch_once_t s_onceToken;
@@ -79,9 +79,9 @@
     return URLComponents.URL;
 }
 
-#pragma mark Legacy image scaling
+#pragma mark Business Unit image scaling service
 
-- (NSURL *)scaledImageURL:(NSURL *)imageURL width:(SRGImageWidth)width
+- (NSURL *)businessUnitScalingServiceURLForImageURL:(NSURL *)imageURL width:(SRGImageWidth)width
 {
     NSString *sizeComponent = [NSString stringWithFormat:@"scale/width/%@", @(width)];
     return [imageURL URLByAppendingPathComponent:sizeComponent];

--- a/Sources/SRGDataProviderRequests/SRGDataProvider+ImageURLs.m
+++ b/Sources/SRGDataProviderRequests/SRGDataProvider+ImageURLs.m
@@ -32,6 +32,7 @@
         return imageURL;
     }
     
+    // See https://github.com/SRGSSR/srgdataprovider-apple/issues/47
     if ([imageURL.host containsString:@"rts.ch"] && [imageURL.path containsString:@".image"]) {
         return [self businessUnitScalingServiceURLForImageURL:imageURL width:width];
     }

--- a/Sources/SRGDataProviderRequests/SRGDataProvider+ImageURLs.m
+++ b/Sources/SRGDataProviderRequests/SRGDataProvider+ImageURLs.m
@@ -64,8 +64,8 @@
     
     NSURL *URL = [rootServiceURLComponents.URL URLByAppendingPathComponent:@"images/"];
     NSURLComponents *URLComponents = [NSURLComponents componentsWithURL:URL resolvingAgainstBaseURL:NO];
-
-    NSString *format = s_formats[imageURL.pathExtension] ?: @"jpg";
+    
+    NSString *format = s_formats[imageURL.pathExtension] ?: s_formats[imageURL.pathComponents.lastObject] ?: @"jpg";
     URLComponents.queryItems = @[
         [NSURLQueryItem queryItemWithName:@"imageUrl" value:imageURL.absoluteString],
         [NSURLQueryItem queryItemWithName:@"format" value:format],

--- a/Sources/SRGDataProviderRequests/SRGDataProvider+ImageURLs.m
+++ b/Sources/SRGDataProviderRequests/SRGDataProvider+ImageURLs.m
@@ -12,17 +12,17 @@
 
 #pragma mark Public methods
 
-- (NSURL *)requestURLForImage:(SRGImage *)image withWidth:(SRGImageWidth)width scaling:(SRGImageScaling)scaling
+- (NSURL *)requestURLForImage:(SRGImage *)image withWidth:(SRGImageWidth)width scalingService:(SRGImageScalingService)scalingService
 {
-    return [self requestURLForImageURL:image.URL withWidth:width scaling:scaling];
+    return [self requestURLForImageURL:image.URL withWidth:width scalingService:scalingService];
 }
 
-- (NSURL *)requestURLForImage:(SRGImage *)image withSize:(SRGImageSize)size scaling:(SRGImageScaling)scaling
+- (NSURL *)requestURLForImage:(SRGImage *)image withSize:(SRGImageSize)size scalingService:(SRGImageScalingService)scalingService
 {
-    return [self requestURLForImageURL:image.URL withSize:size variant:image.variant scaling:scaling];
+    return [self requestURLForImageURL:image.URL withSize:size variant:image.variant scalingService:scalingService];
 }
 
-- (NSURL *)requestURLForImageURL:(NSURL *)imageURL withWidth:(SRGImageWidth)width scaling:(SRGImageScaling)scaling
+- (NSURL *)requestURLForImageURL:(NSURL *)imageURL withWidth:(SRGImageWidth)width scalingService:(SRGImageScalingService)scalingService
 {
     if (! imageURL) {
         return nil;
@@ -32,39 +32,22 @@
         return imageURL;
     }
     
-    switch (scaling) {
-        case SRGImageScalingAspectFitSixteenToNine: {
-            return [self scaledImageURLForResourcePath:@"integrationlayer/2.0/image-scale-pillarbox" imageURL:imageURL width:width];
-            break;
-        }
-        
-        case SRGImageScalingAspectFitBlackSquare: {
-            return [self scaledImageURLForResourcePath:@"integrationlayer/2.0/image-scale-one-to-one" imageURL:imageURL width:width];
-            break;
-        }
-        
-        case SRGImageScalingAspectFitTransparentSquare: {
-            return [self scaledImageURLForResourcePath:@"integrationlayer/2.0/image-scale-one-to-one-transparent-background" imageURL:imageURL width:width];
-            break;
-        }
-            
-        case SRGImageScalingPreserveAspectRatio: {
+    switch (scalingService) {
+        case SRGImageScalingServiceIntegrationLayer: {
             return [self imageServiceURLForImageURL:imageURL width:width];
             break;
         }
             
         default: {
-            // We do not use `integrationlayer/2.0/image-scale-sixteen-to-nine` here since it delivers PNGs, too costly
-            // in comparison to resource paths scaling delivering JPEG.
             return [self scaledImageURL:imageURL width:width];
             break;
         }
     }
 }
 
-- (NSURL *)requestURLForImageURL:(NSURL *)imageURL withSize:(SRGImageSize)size variant:(SRGImageVariant)variant scaling:(SRGImageScaling)scaling
+- (NSURL *)requestURLForImageURL:(NSURL *)imageURL withSize:(SRGImageSize)size variant:(SRGImageVariant)variant scalingService:(SRGImageScalingService)scalingService
 {
-    return [self requestURLForImageURL:imageURL withWidth:SRGRecommendedImageWidth(size, variant) scaling:scaling];
+    return [self requestURLForImageURL:imageURL withWidth:SRGRecommendedImageWidth(size, variant) scalingService:scalingService];
 }
 
 #pragma mark Modern image scaling
@@ -102,12 +85,6 @@
 {
     NSString *sizeComponent = [NSString stringWithFormat:@"scale/width/%@", @(width)];
     return [imageURL URLByAppendingPathComponent:sizeComponent];
-}
-
-- (NSURL *)scaledImageURLForResourcePath:(NSString *)resourcePath imageURL:(NSURL *)imageURL width:(SRGImageWidth)width
-{
-    NSString *sizeComponent = [NSString stringWithFormat:@"scale/width/%@", @(width)];
-    return [[[self.serviceURL URLByAppendingPathComponent:resourcePath] URLByAppendingPathComponent:imageURL.absoluteString] URLByAppendingPathComponent:sizeComponent];
 }
 
 @end

--- a/Sources/SRGDataProviderRequests/SRGDataProvider+ImageURLs.m
+++ b/Sources/SRGDataProviderRequests/SRGDataProvider+ImageURLs.m
@@ -12,17 +12,17 @@
 
 #pragma mark Public methods
 
-- (NSURL *)requestURLForImage:(SRGImage *)image withWidth:(SRGImageWidth)width scalingService:(SRGImageScalingService)scalingService
+- (NSURL *)requestURLForImage:(SRGImage *)image withWidth:(SRGImageWidth)width
 {
-    return [self requestURLForImageURL:image.URL withWidth:width scalingService:scalingService];
+    return [self requestURLForImageURL:image.URL withWidth:width];
 }
 
-- (NSURL *)requestURLForImage:(SRGImage *)image withSize:(SRGImageSize)size scalingService:(SRGImageScalingService)scalingService
+- (NSURL *)requestURLForImage:(SRGImage *)image withSize:(SRGImageSize)size
 {
-    return [self requestURLForImageURL:image.URL withSize:size variant:image.variant scalingService:scalingService];
+    return [self requestURLForImageURL:image.URL withSize:size variant:image.variant];
 }
 
-- (NSURL *)requestURLForImageURL:(NSURL *)imageURL withWidth:(SRGImageWidth)width scalingService:(SRGImageScalingService)scalingService
+- (NSURL *)requestURLForImageURL:(NSURL *)imageURL withWidth:(SRGImageWidth)width
 {
     if (! imageURL) {
         return nil;
@@ -32,27 +32,22 @@
         return imageURL;
     }
     
-    switch (scalingService) {
-        case SRGImageScalingServiceCentralized: {
-            return [self centralizedScalingServiceURLForImageURL:imageURL width:width];
-            break;
-        }
-            
-        default: {
-            return [self businessUnitScalingServiceURLForImageURL:imageURL width:width];
-            break;
-        }
+    if ([imageURL.host containsString:@"rts.ch"] && [imageURL.path containsString:@".image"]) {
+        return [self businessUnitScalingServiceURLForImageURL:imageURL width:width];
+    }
+    else {
+        return [self playsrgScalingServiceURLForImageURL:imageURL width:width];
     }
 }
 
-- (NSURL *)requestURLForImageURL:(NSURL *)imageURL withSize:(SRGImageSize)size variant:(SRGImageVariant)variant scalingService:(SRGImageScalingService)scalingService
+- (NSURL *)requestURLForImageURL:(NSURL *)imageURL withSize:(SRGImageSize)size variant:(SRGImageVariant)variant
 {
-    return [self requestURLForImageURL:imageURL withWidth:SRGRecommendedImageWidth(size, variant) scalingService:scalingService];
+    return [self requestURLForImageURL:imageURL withWidth:SRGRecommendedImageWidth(size, variant)];
 }
 
-#pragma mark Centralised image scaling service
+#pragma mark PlaySRG image scaling service
 
-- (NSURL *)centralizedScalingServiceURLForImageURL:(NSURL *)imageURL width:(SRGImageWidth)width
+- (NSURL *)playsrgScalingServiceURLForImageURL:(NSURL *)imageURL width:(SRGImageWidth)width
 {
     static NSDictionary<NSString *, NSString *> *s_formats;
     static dispatch_once_t s_onceToken;

--- a/Sources/SRGDataProviderRequests/include/SRGDataProvider+ImageURLs.h
+++ b/Sources/SRGDataProviderRequests/include/SRGDataProvider+ImageURLs.h
@@ -15,14 +15,14 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SRGDataProvider (ImageURLs)
 
 /**
- *  Return the request URL for an image having a given width and scaled by applying the specified behavior.
+ *  Return the request URL for an image having a given width.
  */
-- (nullable NSURL *)requestURLForImage:(nullable SRGImage *)image withWidth:(SRGImageWidth)width scalingService:(SRGImageScalingService)scaling;
+- (nullable NSURL *)requestURLForImage:(nullable SRGImage *)image withWidth:(SRGImageWidth)width;
 
 /**
- *  Return the request URL for an image having a given semantic size and scaled by applying the specified behavior.
+ *  Return the request URL for an image having a given semantic size.
  */
-- (nullable NSURL *)requestURLForImage:(nullable SRGImage *)image withSize:(SRGImageSize)size scalingService:(SRGImageScalingService)scaling;
+- (nullable NSURL *)requestURLForImage:(nullable SRGImage *)image withSize:(SRGImageSize)size;
 
 @end
 

--- a/Sources/SRGDataProviderRequests/include/SRGDataProvider+ImageURLs.h
+++ b/Sources/SRGDataProviderRequests/include/SRGDataProvider+ImageURLs.h
@@ -17,12 +17,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Return the request URL for an image having a given width and scaled by applying the specified behavior.
  */
-- (nullable NSURL *)requestURLForImage:(nullable SRGImage *)image withWidth:(SRGImageWidth)width scaling:(SRGImageScaling)scaling;
+- (nullable NSURL *)requestURLForImage:(nullable SRGImage *)image withWidth:(SRGImageWidth)width scalingService:(SRGImageScalingService)scaling;
 
 /**
  *  Return the request URL for an image having a given semantic size and scaled by applying the specified behavior.
  */
-- (nullable NSURL *)requestURLForImage:(nullable SRGImage *)image withSize:(SRGImageSize)size scaling:(SRGImageScaling)scaling;
+- (nullable NSURL *)requestURLForImage:(nullable SRGImage *)image withSize:(SRGImageSize)size scalingService:(SRGImageScalingService)scaling;
 
 @end
 

--- a/Tests/SRGDataProviderNetworkTests/ImageServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/ImageServicesTestCase.m
@@ -34,23 +34,7 @@ static NSString * const kVideoURN = @"urn:srf:video:24b1f659-052e-4847-a523-a626
 
 - (void)testFixedSizeImage
 {
-    XCTestExpectation *expectation1 = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, 320.);
-        XCTAssertEqual(image.size.height, 180.);
-        
-        [expectation1 fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-    
-    XCTestExpectation *expectation2 = [self expectationWithDescription:@"Request succeeded"];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
     [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         XCTAssertNotNil(media);
@@ -61,7 +45,27 @@ static NSString * const kVideoURN = @"urn:srf:video:24b1f659-052e-4847-a523-a626
         XCTAssertEqual(image.size.width, 320.);
         XCTAssertEqual(image.size.height, 180.);
         
-        [expectation2 fulfill];
+        [expectation fulfill];
+    }] resume];
+    
+    [self waitForExpectationsWithTimeout:30. handler:nil];
+}
+
+- (void)testSmallSizeImage
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
+    
+    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertNotNil(media);
+        XCTAssertNil(error);
+        
+        CGSize expectedSize = SRGRecommendedImageCGSize(SRGImageSizeSmall, SRGImageVariantDefault);
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeSmall scalingService:SRGImageScalingServiceCentralized];
+        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        XCTAssertEqual(image.size.width, expectedSize.width);
+        XCTAssertEqual(image.size.height, expectedSize.height);
+        
+        [expectation fulfill];
     }] resume];
     
     [self waitForExpectationsWithTimeout:30. handler:nil];
@@ -69,24 +73,7 @@ static NSString * const kVideoURN = @"urn:srf:video:24b1f659-052e-4847-a523-a626
 
 - (void)testMediumSizeImage
 {
-    XCTestExpectation *expectation1 = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        CGSize expectedSize = SRGRecommendedImageCGSize(SRGImageSizeMedium, SRGImageVariantDefault);
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeMedium scalingService:SRGImageScalingServiceDefault];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, expectedSize.width);
-        XCTAssertEqual(image.size.height, expectedSize.height);
-        
-        [expectation1 fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-    
-    XCTestExpectation *expectation2 = [self expectationWithDescription:@"Request succeeded"];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
     [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         XCTAssertNotNil(media);
@@ -98,7 +85,7 @@ static NSString * const kVideoURN = @"urn:srf:video:24b1f659-052e-4847-a523-a626
         XCTAssertEqual(image.size.width, expectedSize.width);
         XCTAssertEqual(image.size.height, expectedSize.height);
         
-        [expectation2 fulfill];
+        [expectation fulfill];
     }] resume];
     
     [self waitForExpectationsWithTimeout:30. handler:nil];
@@ -106,24 +93,7 @@ static NSString * const kVideoURN = @"urn:srf:video:24b1f659-052e-4847-a523-a626
 
 - (void)testLargeSizeImage
 {
-    XCTestExpectation *expectation1 = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        CGSize expectedSize = SRGRecommendedImageCGSize(SRGImageSizeLarge, SRGImageVariantDefault);
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeLarge scalingService:SRGImageScalingServiceDefault];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, expectedSize.width);
-        XCTAssertEqual(image.size.height, expectedSize.height);
-        
-        [expectation1 fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-    
-    XCTestExpectation *expectation2 = [self expectationWithDescription:@"Request succeeded"];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
     [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         XCTAssertNotNil(media);
@@ -135,7 +105,7 @@ static NSString * const kVideoURN = @"urn:srf:video:24b1f659-052e-4847-a523-a626
         XCTAssertEqual(image.size.width, expectedSize.width);
         XCTAssertEqual(image.size.height, expectedSize.height);
         
-        [expectation2 fulfill];
+        [expectation fulfill];
     }] resume];
     
     [self waitForExpectationsWithTimeout:30. handler:nil];

--- a/Tests/SRGDataProviderNetworkTests/ImageServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/ImageServicesTestCase.m
@@ -56,7 +56,7 @@ static NSString * const kVideoURN = @"urn:srf:video:24b1f659-052e-4847-a523-a626
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceIntegrationLayer];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         XCTAssertEqual(image.size.height, 180.);
@@ -93,7 +93,7 @@ static NSString * const kVideoURN = @"urn:srf:video:24b1f659-052e-4847-a523-a626
         XCTAssertNil(error);
         
         CGSize expectedSize = SRGRecommendedImageCGSize(SRGImageSizeMedium, SRGImageVariantDefault);
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeMedium scalingService:SRGImageScalingServiceIntegrationLayer];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeMedium scalingService:SRGImageScalingServiceCentralized];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, expectedSize.width);
         XCTAssertEqual(image.size.height, expectedSize.height);
@@ -130,7 +130,7 @@ static NSString * const kVideoURN = @"urn:srf:video:24b1f659-052e-4847-a523-a626
         XCTAssertNil(error);
         
         CGSize expectedSize = SRGRecommendedImageCGSize(SRGImageSizeLarge, SRGImageVariantDefault);
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeLarge scalingService:SRGImageScalingServiceIntegrationLayer];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeLarge scalingService:SRGImageScalingServiceCentralized];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, expectedSize.width);
         XCTAssertEqual(image.size.height, expectedSize.height);

--- a/Tests/SRGDataProviderNetworkTests/ImageServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/ImageServicesTestCase.m
@@ -40,7 +40,7 @@ static NSString * const kVideoURN = @"urn:srf:video:24b1f659-052e-4847-a523-a626
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         XCTAssertEqual(image.size.height, 180.);
@@ -60,7 +60,7 @@ static NSString * const kVideoURN = @"urn:srf:video:24b1f659-052e-4847-a523-a626
         XCTAssertNil(error);
         
         CGSize expectedSize = SRGRecommendedImageCGSize(SRGImageSizeSmall, SRGImageVariantDefault);
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeSmall scalingService:SRGImageScalingServiceCentralized];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeSmall];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, expectedSize.width);
         XCTAssertEqual(image.size.height, expectedSize.height);
@@ -80,7 +80,7 @@ static NSString * const kVideoURN = @"urn:srf:video:24b1f659-052e-4847-a523-a626
         XCTAssertNil(error);
         
         CGSize expectedSize = SRGRecommendedImageCGSize(SRGImageSizeMedium, SRGImageVariantDefault);
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeMedium scalingService:SRGImageScalingServiceCentralized];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeMedium];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, expectedSize.width);
         XCTAssertEqual(image.size.height, expectedSize.height);
@@ -100,7 +100,7 @@ static NSString * const kVideoURN = @"urn:srf:video:24b1f659-052e-4847-a523-a626
         XCTAssertNil(error);
         
         CGSize expectedSize = SRGRecommendedImageCGSize(SRGImageSizeLarge, SRGImageVariantDefault);
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeLarge scalingService:SRGImageScalingServiceCentralized];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeLarge];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, expectedSize.width);
         XCTAssertEqual(image.size.height, expectedSize.height);

--- a/Tests/SRGDataProviderNetworkTests/ImageServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/ImageServicesTestCase.m
@@ -32,135 +32,36 @@ static NSString * const kVideoURN = @"urn:srf:video:24b1f659-052e-4847-a523-a626
 
 #pragma mark Tests
 
-- (void)testImageScalingDefault
+- (void)testFixedSizeImage
 {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
+    XCTestExpectation *expectation1 = [self expectationWithDescription:@"Request succeeded"];
     
     [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scaling:SRGImageScalingDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         XCTAssertEqual(image.size.height, 180.);
         
-        [expectation fulfill];
+        [expectation1 fulfill];
     }] resume];
     
     [self waitForExpectationsWithTimeout:30. handler:nil];
-}
-
-- (void)testImageScalingPreserveAspectRatio
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
+    
+    XCTestExpectation *expectation2 = [self expectationWithDescription:@"Request succeeded"];
     
     [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scaling:SRGImageScalingPreserveAspectRatio];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceIntegrationLayer];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         XCTAssertEqual(image.size.height, 180.);
         
-        [expectation fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-}
-
-- (void)testImageScalingAspectFitSixteenToNine
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scaling:SRGImageScalingAspectFitSixteenToNine];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, 320.);
-        XCTAssertEqual(image.size.height, 180.);
-        
-        [expectation fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-}
-
-- (void)testImageScalingAspectFillSixteenToNine
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scaling:SRGImageScalingAspectFitSixteenToNine];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, 320.);
-        XCTAssertEqual(image.size.height, 180.);
-        
-        [expectation fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-}
-
-- (void)testImageScalingAspectFitBlackSquare
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scaling:SRGImageScalingAspectFitBlackSquare];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, 320.);
-        XCTAssertEqual(image.size.height, 320.);
-        
-        [expectation fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-}
-
-- (void)testImageScalingAspectFitTransparentSquare
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scaling:SRGImageScalingAspectFitTransparentSquare];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, 320.);
-        XCTAssertEqual(image.size.height, 320.);
-        
-        [expectation fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-}
-
-- (void)testSmallSizeImage
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        CGSize expectedSize = SRGRecommendedImageCGSize(SRGImageSizeSmall, SRGImageVariantDefault);
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeSmall scaling:SRGImageScalingDefault];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, expectedSize.width);
-        XCTAssertEqual(image.size.height, expectedSize.height);
-        
-        [expectation fulfill];
+        [expectation2 fulfill];
     }] resume];
     
     [self waitForExpectationsWithTimeout:30. handler:nil];
@@ -168,19 +69,36 @@ static NSString * const kVideoURN = @"urn:srf:video:24b1f659-052e-4847-a523-a626
 
 - (void)testMediumSizeImage
 {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
+    XCTestExpectation *expectation1 = [self expectationWithDescription:@"Request succeeded"];
     
     [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
         CGSize expectedSize = SRGRecommendedImageCGSize(SRGImageSizeMedium, SRGImageVariantDefault);
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeMedium scaling:SRGImageScalingDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeMedium scalingService:SRGImageScalingServiceDefault];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, expectedSize.width);
         XCTAssertEqual(image.size.height, expectedSize.height);
         
-        [expectation fulfill];
+        [expectation1 fulfill];
+    }] resume];
+    
+    [self waitForExpectationsWithTimeout:30. handler:nil];
+    
+    XCTestExpectation *expectation2 = [self expectationWithDescription:@"Request succeeded"];
+    
+    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertNotNil(media);
+        XCTAssertNil(error);
+        
+        CGSize expectedSize = SRGRecommendedImageCGSize(SRGImageSizeMedium, SRGImageVariantDefault);
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeMedium scalingService:SRGImageScalingServiceIntegrationLayer];
+        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        XCTAssertEqual(image.size.width, expectedSize.width);
+        XCTAssertEqual(image.size.height, expectedSize.height);
+        
+        [expectation2 fulfill];
     }] resume];
     
     [self waitForExpectationsWithTimeout:30. handler:nil];
@@ -188,19 +106,36 @@ static NSString * const kVideoURN = @"urn:srf:video:24b1f659-052e-4847-a523-a626
 
 - (void)testLargeSizeImage
 {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
+    XCTestExpectation *expectation1 = [self expectationWithDescription:@"Request succeeded"];
     
     [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
         CGSize expectedSize = SRGRecommendedImageCGSize(SRGImageSizeLarge, SRGImageVariantDefault);
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeLarge scaling:SRGImageScalingDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeLarge scalingService:SRGImageScalingServiceDefault];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, expectedSize.width);
         XCTAssertEqual(image.size.height, expectedSize.height);
         
-        [expectation fulfill];
+        [expectation1 fulfill];
+    }] resume];
+    
+    [self waitForExpectationsWithTimeout:30. handler:nil];
+    
+    XCTestExpectation *expectation2 = [self expectationWithDescription:@"Request succeeded"];
+    
+    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertNotNil(media);
+        XCTAssertNil(error);
+        
+        CGSize expectedSize = SRGRecommendedImageCGSize(SRGImageSizeLarge, SRGImageVariantDefault);
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withSize:SRGImageSizeLarge scalingService:SRGImageScalingServiceIntegrationLayer];
+        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        XCTAssertEqual(image.size.width, expectedSize.width);
+        XCTAssertEqual(image.size.height, expectedSize.height);
+        
+        [expectation2 fulfill];
     }] resume];
     
     [self waitForExpectationsWithTimeout:30. handler:nil];

--- a/Tests/SRGDataProviderNetworkTests/RSIServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RSIServicesTestCase.m
@@ -1083,7 +1083,7 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testVideoImageFromBusinessUnitService
+- (void)testVideoImage
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -1091,9 +1091,11 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        // 16/9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
+        XCTAssertEqual(image.size.height, 180.);
         
         [expectation fulfill];
     }] resume];
@@ -1101,7 +1103,7 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testAudioImageFromBusinessUnitService
+- (void)testAudioImage
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -1109,45 +1111,11 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        // 16/9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
-        
-        [expectation fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-}
-
-- (void)testVideoImageFromCentralizedService
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, 320.);
-        
-        [expectation fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-}
-
-- (void)testAudioImageFromCentralizedService
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kAudioURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, 320.);
+        XCTAssertEqual(image.size.height, 180.);
         
         [expectation fulfill];
     }] resume];

--- a/Tests/SRGDataProviderNetworkTests/RSIServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RSIServicesTestCase.m
@@ -1091,7 +1091,7 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scaling:SRGImageScalingDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         
@@ -1109,7 +1109,7 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scaling:SRGImageScalingDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         

--- a/Tests/SRGDataProviderNetworkTests/RSIServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RSIServicesTestCase.m
@@ -1093,7 +1093,7 @@ static NSString * const kUserId = @"test_user_id";
         
         NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        // 16/9 ratio expected
+        // 16:9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
         XCTAssertEqual(image.size.height, 180.);
         
@@ -1113,7 +1113,7 @@ static NSString * const kUserId = @"test_user_id";
         
         NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        // 16/9 ratio expected
+        // 16:9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
         XCTAssertEqual(image.size.height, 180.);
         

--- a/Tests/SRGDataProviderNetworkTests/RSIServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RSIServicesTestCase.m
@@ -1083,7 +1083,7 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testVideoImage
+- (void)testVideoImageFromBusinessUnitService
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -1091,7 +1091,7 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         
@@ -1101,7 +1101,7 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testAudioImage
+- (void)testAudioImageFromBusinessUnitService
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -1109,7 +1109,43 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
+        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        XCTAssertEqual(image.size.width, 320.);
+        
+        [expectation fulfill];
+    }] resume];
+    
+    [self waitForExpectationsWithTimeout:30. handler:nil];
+}
+
+- (void)testVideoImageFromCentralizedService
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
+    
+    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertNotNil(media);
+        XCTAssertNil(error);
+        
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
+        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        XCTAssertEqual(image.size.width, 320.);
+        
+        [expectation fulfill];
+    }] resume];
+    
+    [self waitForExpectationsWithTimeout:30. handler:nil];
+}
+
+- (void)testAudioImageFromCentralizedService
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
+    
+    [[self.dataProvider mediaWithURN:kAudioURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertNotNil(media);
+        XCTAssertNil(error);
+        
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         

--- a/Tests/SRGDataProviderNetworkTests/RTRServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RTRServicesTestCase.m
@@ -1088,7 +1088,7 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scaling:SRGImageScalingDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         
@@ -1106,7 +1106,7 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scaling:SRGImageScalingDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         

--- a/Tests/SRGDataProviderNetworkTests/RTRServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RTRServicesTestCase.m
@@ -1080,7 +1080,7 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testVideoImage
+- (void)testVideoImageFromBusinessUnitService
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -1088,7 +1088,7 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         
@@ -1098,7 +1098,7 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testAudioImage
+- (void)testAudioImageFromBusinessUnitService
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -1106,7 +1106,43 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
+        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        XCTAssertEqual(image.size.width, 320.);
+        
+        [expectation fulfill];
+    }] resume];
+    
+    [self waitForExpectationsWithTimeout:30. handler:nil];
+}
+
+- (void)testVideoImageFromCentralizedService
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
+    
+    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertNotNil(media);
+        XCTAssertNil(error);
+        
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
+        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        XCTAssertEqual(image.size.width, 320.);
+        
+        [expectation fulfill];
+    }] resume];
+    
+    [self waitForExpectationsWithTimeout:30. handler:nil];
+}
+
+- (void)testAudioImageFromCentralizedService
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
+    
+    [[self.dataProvider mediaWithURN:kAudioURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertNotNil(media);
+        XCTAssertNil(error);
+        
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         

--- a/Tests/SRGDataProviderNetworkTests/RTRServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RTRServicesTestCase.m
@@ -1090,7 +1090,7 @@ static NSString * const kUserId = @"test_user_id";
         
         NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        // 16/9 ratio expected
+        // 16:9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
         XCTAssertEqual(image.size.height, 180.);
         
@@ -1110,7 +1110,7 @@ static NSString * const kUserId = @"test_user_id";
         
         NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        // 16/9 ratio expected
+        // 16:9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
         XCTAssertEqual(image.size.height, 180.);
         

--- a/Tests/SRGDataProviderNetworkTests/RTRServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RTRServicesTestCase.m
@@ -1080,7 +1080,7 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testVideoImageFromBusinessUnitService
+- (void)testVideoImage
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -1088,9 +1088,11 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        // 16/9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
+        XCTAssertEqual(image.size.height, 180.);
         
         [expectation fulfill];
     }] resume];
@@ -1098,7 +1100,7 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testAudioImageFromBusinessUnitService
+- (void)testAudioImage
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -1106,45 +1108,11 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        // 16/9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
-        
-        [expectation fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-}
-
-- (void)testVideoImageFromCentralizedService
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, 320.);
-        
-        [expectation fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-}
-
-- (void)testAudioImageFromCentralizedService
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kAudioURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, 320.);
+        XCTAssertEqual(image.size.height, 180.);
         
         [expectation fulfill];
     }] resume];

--- a/Tests/SRGDataProviderNetworkTests/RTSServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RTSServicesTestCase.m
@@ -1099,7 +1099,7 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testVideoImage
+- (void)testVideoImageFromBusinessUnitService
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -1107,7 +1107,7 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         
@@ -1117,7 +1117,7 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testAudioImage
+- (void)testAudioImageFromBusinessUnitService
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -1125,7 +1125,43 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
+        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        XCTAssertEqual(image.size.width, 320.);
+        
+        [expectation fulfill];
+    }] resume];
+    
+    [self waitForExpectationsWithTimeout:30. handler:nil];
+}
+
+- (void)testVideoImageFromCentralizedService
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
+    
+    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertNotNil(media);
+        XCTAssertNil(error);
+        
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
+        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        XCTAssertEqual(image.size.width, 320.);
+        
+        [expectation fulfill];
+    }] resume];
+    
+    [self waitForExpectationsWithTimeout:30. handler:nil];
+}
+
+- (void)testAudioImageFromCentralizedService
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
+    
+    [[self.dataProvider mediaWithURN:kAudioURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertNotNil(media);
+        XCTAssertNil(error);
+        
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         

--- a/Tests/SRGDataProviderNetworkTests/RTSServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RTSServicesTestCase.m
@@ -10,7 +10,7 @@
 @import libextobjc;
 
 static NSString * const kAudioSearchQuery = @"roger";
-static NSString * const kAudioURN = @"urn:rts:audio:8438184";
+static NSString * const kAudioURN = @"urn:rts:audio:14145940";
 
 static NSString * const kRadioChannelUid = @"a9e7621504c6959e35c3ecbe7f6bed0446cdf8da";
 static NSString * const kRadioLivestreamUid = @"3262320";
@@ -1099,7 +1099,7 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testVideoImageFromBusinessUnitService
+- (void)testVideoImage
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -1107,9 +1107,11 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        // 16/9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
+        XCTAssertEqual(image.size.height, 180.);
         
         [expectation fulfill];
     }] resume];
@@ -1117,7 +1119,7 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testAudioImageFromBusinessUnitService
+- (void)testAudioImage
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -1125,45 +1127,11 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        // 16/9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
-        
-        [expectation fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-}
-
-- (void)testVideoImageFromCentralizedService
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, 320.);
-        
-        [expectation fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-}
-
-- (void)testAudioImageFromCentralizedService
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kAudioURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, 320.);
+        XCTAssertEqual(image.size.height, 180.);
         
         [expectation fulfill];
     }] resume];

--- a/Tests/SRGDataProviderNetworkTests/RTSServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RTSServicesTestCase.m
@@ -1109,7 +1109,7 @@ static NSString * const kUserId = @"test_user_id";
         
         NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        // 16/9 ratio expected
+        // 16:9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
         XCTAssertEqual(image.size.height, 180.);
         
@@ -1129,7 +1129,7 @@ static NSString * const kUserId = @"test_user_id";
         
         NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        // 16/9 ratio expected
+        // 16:9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
         XCTAssertEqual(image.size.height, 180.);
         

--- a/Tests/SRGDataProviderNetworkTests/RTSServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RTSServicesTestCase.m
@@ -1107,7 +1107,7 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scaling:SRGImageScalingDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         
@@ -1125,7 +1125,7 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scaling:SRGImageScalingDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         

--- a/Tests/SRGDataProviderNetworkTests/SRFServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/SRFServicesTestCase.m
@@ -1111,7 +1111,7 @@ static NSString * const kTag2 = @"curling";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scaling:SRGImageScalingDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         
@@ -1129,7 +1129,7 @@ static NSString * const kTag2 = @"curling";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scaling:SRGImageScalingDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         

--- a/Tests/SRGDataProviderNetworkTests/SRFServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/SRFServicesTestCase.m
@@ -1113,7 +1113,7 @@ static NSString * const kTag2 = @"curling";
         
         NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        // 16/9 ratio expected
+        // 16:9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
         XCTAssertEqual(image.size.height, 180.);
         
@@ -1133,7 +1133,7 @@ static NSString * const kTag2 = @"curling";
         
         NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        // 16/9 ratio expected
+        // 16:9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
         XCTAssertEqual(image.size.height, 180.);
         

--- a/Tests/SRGDataProviderNetworkTests/SRFServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/SRFServicesTestCase.m
@@ -1103,7 +1103,7 @@ static NSString * const kTag2 = @"curling";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testVideoImageFromBusinessUnitService
+- (void)testVideoImage
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -1111,9 +1111,11 @@ static NSString * const kTag2 = @"curling";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        // 16/9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
+        XCTAssertEqual(image.size.height, 180.);
         
         [expectation fulfill];
     }] resume];
@@ -1121,7 +1123,7 @@ static NSString * const kTag2 = @"curling";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testAudioImageFromBusinessUnitService
+- (void)testAudioImage
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -1129,45 +1131,11 @@ static NSString * const kTag2 = @"curling";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        // 16/9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
-        
-        [expectation fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-}
-
-- (void)testVideoImageFromCentralizedService
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, 320.);
-        
-        [expectation fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-}
-
-- (void)testAudioImageFromCentralizedService
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kAudioURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, 320.);
+        XCTAssertEqual(image.size.height, 180.);
         
         [expectation fulfill];
     }] resume];

--- a/Tests/SRGDataProviderNetworkTests/SRFServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/SRFServicesTestCase.m
@@ -1103,7 +1103,7 @@ static NSString * const kTag2 = @"curling";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testVideoImage
+- (void)testVideoImageFromBusinessUnitService
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -1111,7 +1111,7 @@ static NSString * const kTag2 = @"curling";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         
@@ -1121,7 +1121,7 @@ static NSString * const kTag2 = @"curling";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testAudioImage
+- (void)testAudioImageFromBusinessUnitService
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -1129,7 +1129,43 @@ static NSString * const kTag2 = @"curling";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
+        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        XCTAssertEqual(image.size.width, 320.);
+        
+        [expectation fulfill];
+    }] resume];
+    
+    [self waitForExpectationsWithTimeout:30. handler:nil];
+}
+
+- (void)testVideoImageFromCentralizedService
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
+    
+    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertNotNil(media);
+        XCTAssertNil(error);
+        
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
+        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        XCTAssertEqual(image.size.width, 320.);
+        
+        [expectation fulfill];
+    }] resume];
+    
+    [self waitForExpectationsWithTimeout:30. handler:nil];
+}
+
+- (void)testAudioImageFromCentralizedService
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
+    
+    [[self.dataProvider mediaWithURN:kAudioURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertNotNil(media);
+        XCTAssertNil(error);
+        
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         

--- a/Tests/SRGDataProviderNetworkTests/SWIServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/SWIServicesTestCase.m
@@ -960,7 +960,7 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testVideoImageFromBusinessUnitService
+- (void)testVideoImage
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -968,27 +968,11 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        // 16/9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
-        
-        [expectation fulfill];
-    }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-}
-
-- (void)testVideoImageFromCentralizedService
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(media);
-        XCTAssertNil(error);
-        
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
-        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        XCTAssertEqual(image.size.width, 320.);
+        XCTAssertEqual(image.size.height, 180.);
         
         [expectation fulfill];
     }] resume];

--- a/Tests/SRGDataProviderNetworkTests/SWIServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/SWIServicesTestCase.m
@@ -960,7 +960,7 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-- (void)testVideoImage
+- (void)testVideoImageFromBusinessUnitService
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
@@ -968,7 +968,25 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceBusinessUnit];
+        UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
+        XCTAssertEqual(image.size.width, 320.);
+        
+        [expectation fulfill];
+    }] resume];
+    
+    [self waitForExpectationsWithTimeout:30. handler:nil];
+}
+
+- (void)testVideoImageFromCentralizedService
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
+    
+    [[self.dataProvider mediaWithURN:kVideoURN completionBlock:^(SRGMedia * _Nullable media, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertNotNil(media);
+        XCTAssertNil(error);
+        
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceCentralized];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         

--- a/Tests/SRGDataProviderNetworkTests/SWIServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/SWIServicesTestCase.m
@@ -970,7 +970,7 @@ static NSString * const kUserId = @"test_user_id";
         
         NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        // 16/9 ratio expected
+        // 16:9 ratio expected
         XCTAssertEqual(image.size.width, 320.);
         XCTAssertEqual(image.size.height, 180.);
         

--- a/Tests/SRGDataProviderNetworkTests/SWIServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/SWIServicesTestCase.m
@@ -968,7 +968,7 @@ static NSString * const kUserId = @"test_user_id";
         XCTAssertNotNil(media);
         XCTAssertNil(error);
         
-        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scaling:SRGImageScalingDefault];
+        NSURL *imageURL = [self.dataProvider URLForImage:media.image withWidth:SRGImageWidth320 scalingService:SRGImageScalingServiceDefault];
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
         XCTAssertEqual(image.size.width, 320.);
         

--- a/Tests/SRGDataProviderRequestsTests/ImageURLsTestCase.m
+++ b/Tests/SRGDataProviderRequestsTests/ImageURLsTestCase.m
@@ -1,0 +1,196 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@import SRGDataProviderRequests;
+@import XCTest;
+
+@interface NSURLComponents (ImageURLsTestCase)
+
+@property (nonatomic, readonly) NSString *imageUrlQueryValue;
+@property (nonatomic, readonly) NSString *widthQueryValue;
+@property (nonatomic, readonly) NSString *formatQueryValue;
+
+@end
+
+@interface ImageURLsTestCase : XCTestCase
+
+@property (nonatomic) SRGDataProvider *dataProvider;
+
+@end
+
+@implementation ImageURLsTestCase
+
+#pragma mark Setup and teardown
+
+- (void)setUp
+{
+    self.dataProvider = [[SRGDataProvider alloc] initWithServiceURL:SRGIntegrationLayerProductionServiceURL()];
+}
+
+#pragma mark Helpers
+
+- (NSURLComponents *)componentsFromUrlString:(NSString *)urlString width:(SRGImageWidth)width
+{
+    SRGImage *image = [[SRGImage alloc] initWithURL:[NSURL URLWithString:urlString] variant:SRGImageVariantDefault];
+    
+    NSURL *url = [self.dataProvider requestURLForImage:image withWidth:width];
+    NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+    
+    return components;
+}
+
+#pragma mark Tests
+
+- (void)testVideoRSIImage
+{
+    NSString *urlString = @"http://www.rsi.ch/rsi-api/resize/image/EPISODE_IMAGE/9014815/";
+    NSURLComponents *components = [self componentsFromUrlString:urlString width:SRGImageWidth320];
+    
+    XCTAssertEqualObjects(components.host, @"il.srgssr.ch");
+    XCTAssertEqual([components.path rangeOfString:@"/images"].location, 0);
+    XCTAssertEqualObjects(components.imageUrlQueryValue, urlString);
+    XCTAssertEqualObjects(components.widthQueryValue, @"320");
+    XCTAssertEqualObjects(components.formatQueryValue, @"jpg");
+}
+
+- (void)testAudioRSIImage
+{
+    NSString *urlString = @"http://www.rsi.ch/rsi-api/resize/image/EPISODE_IMAGE/12471012/";
+    NSURLComponents *components = [self componentsFromUrlString:urlString width:SRGImageWidth320];
+    
+    XCTAssertEqualObjects(components.host, @"il.srgssr.ch");
+    XCTAssertEqual([components.path rangeOfString:@"/images"].location, 0);
+    XCTAssertEqualObjects(components.imageUrlQueryValue, urlString);
+    XCTAssertEqualObjects(components.widthQueryValue, @"320");
+    XCTAssertEqualObjects(components.formatQueryValue, @"jpg");
+}
+
+- (void)testVideoRTRImage
+{
+    NSString *urlString = @"https://ws.srf.ch/asset/image/audio/0cf00288-7a91-44bb-a4d5-951d3e72a464/EPISODE_IMAGE/1490033307.png";
+    NSURLComponents *components = [self componentsFromUrlString:urlString width:SRGImageWidth320];
+    
+    XCTAssertEqualObjects(components.host, @"il.srgssr.ch");
+    XCTAssertEqual([components.path rangeOfString:@"/images"].location, 0);
+    XCTAssertEqualObjects(components.imageUrlQueryValue, urlString);
+    XCTAssertEqualObjects(components.widthQueryValue, @"320");
+    XCTAssertEqualObjects(components.formatQueryValue, @"png");
+}
+
+- (void)testAudioRTRImage
+{
+    NSString *urlString = @"https://il.srgssr.ch/integrationlayer/2.0/image-scale-sixteen-to-nine/https://www.srf.ch/static/radio/modules/data/pictures/rtr/2017/03/21/453527.91989900.jpg";
+    NSURLComponents *components = [self componentsFromUrlString:urlString width:SRGImageWidth320];
+    
+    XCTAssertEqualObjects(components.host, @"il.srgssr.ch");
+    XCTAssertEqual([components.path rangeOfString:@"/images"].location, 0);
+    XCTAssertEqualObjects(components.imageUrlQueryValue, urlString);
+    XCTAssertEqualObjects(components.widthQueryValue, @"320");
+    XCTAssertEqualObjects(components.formatQueryValue, @"jpg");
+}
+
+- (void)testVideoRTSImage
+{
+    NSString *urlString = @"https://www.rts.ch/2017/03/20/20/17/8478254.image/16x9";
+    NSURLComponents *components = [self componentsFromUrlString:urlString width:SRGImageWidth320];
+    
+    // Business unit image service
+    XCTAssertEqualObjects(components.host, @"www.rts.ch");
+    XCTAssertEqual([components.string rangeOfString:urlString].location, 0);
+    XCTAssertNotEqual([components.path rangeOfString:@"/scale/width/320"].location, NSNotFound);
+}
+
+- (void)testAudioRTSImage
+{
+    NSString *urlString = @"https://www.rts.ch/2021/04/30/14/43/7978319.image/16x9";
+    NSURLComponents *components = [self componentsFromUrlString:urlString width:SRGImageWidth320];
+    
+    // Business unit image service
+    XCTAssertEqualObjects(components.host, @"www.rts.ch");
+    XCTAssertEqual([components.string rangeOfString:urlString].location, 0);
+    XCTAssertNotEqual([components.path rangeOfString:@"/scale/width/320"].location, NSNotFound);
+}
+
+- (void)testVideoSRFImage
+{
+    NSString *urlString = @"https://ws.srf.ch/asset/image/audio/7e18e733-622b-4bd5-9323-971239e49844/WEBVISUAL/1607950376.jpg";
+    NSURLComponents *components = [self componentsFromUrlString:urlString width:SRGImageWidth320];
+    
+    XCTAssertEqualObjects(components.host, @"il.srgssr.ch");
+    XCTAssertEqual([components.path rangeOfString:@"/images"].location, 0);
+    XCTAssertEqualObjects(components.imageUrlQueryValue, urlString);
+    XCTAssertEqualObjects(components.widthQueryValue, @"320");
+    XCTAssertEqualObjects(components.formatQueryValue, @"jpg");
+}
+
+- (void)testAudioSRFImage
+{
+    NSString *urlString = @"https://ws.srf.ch/asset/image/audio/aa35a39d-85cc-4dc4-bf54-8d744cd6304f/EPISODE_IMAGE/1683198311.png";
+    NSURLComponents *components = [self componentsFromUrlString:urlString width:SRGImageWidth320];
+
+    XCTAssertEqualObjects(components.host, @"il.srgssr.ch");
+    XCTAssertEqual([components.path rangeOfString:@"/images"].location, 0);
+    XCTAssertEqualObjects(components.imageUrlQueryValue, urlString);
+    XCTAssertEqualObjects(components.widthQueryValue, @"320");
+    XCTAssertEqualObjects(components.formatQueryValue, @"png");
+}
+
+- (void)testVideoSWIImage
+{
+    NSString *urlString = @"https://www.swissinfo.ch/srgscalableimage/43018064/16x9";
+    NSURLComponents *components = [self componentsFromUrlString:urlString width:SRGImageWidth320];
+    
+    XCTAssertEqualObjects(components.host, @"il.srgssr.ch");
+    XCTAssertEqual([components.path rangeOfString:@"/images"].location, 0);
+    XCTAssertEqualObjects(components.imageUrlQueryValue, urlString);
+    XCTAssertEqualObjects(components.widthQueryValue, @"320");
+    XCTAssertEqualObjects(components.formatQueryValue, @"jpg");
+}
+
+- (void)testUploadedPACImage
+{
+    NSString *urlString = @"https://il.srgssr.ch/integrationlayer/2.0/image-scale-sixteen-to-nine/https://play-pac-public-production.s3.eu-central-1.amazonaws.com/images/19bca29e-90b2-45af-9067-28b0755d0305.jpeg";
+    NSURLComponents *components = [self componentsFromUrlString:urlString width:SRGImageWidth320];
+    
+    XCTAssertEqualObjects(components.host, @"il.srgssr.ch");
+    XCTAssertEqual([components.path rangeOfString:@"/images"].location, 0);
+    XCTAssertEqualObjects(components.imageUrlQueryValue, urlString);
+    XCTAssertEqualObjects(components.widthQueryValue, @"320");
+    XCTAssertEqualObjects(components.formatQueryValue, @"jpg");
+}
+
+- (void)testProgramGuideRawImage
+{
+    NSString *urlString = @"https://il.srgssr.ch/image-service/dynamic/7ec4fb9e.svg";
+    NSURLComponents *components = [self componentsFromUrlString:urlString width:SRGImageWidth320];
+    
+    XCTAssertEqualObjects(components.host, @"il.srgssr.ch");
+    XCTAssertEqual([components.path rangeOfString:@"/images"].location, 0);
+    XCTAssertEqualObjects(components.imageUrlQueryValue, urlString);
+    XCTAssertEqualObjects(components.widthQueryValue, @"320");
+    XCTAssertEqualObjects(components.formatQueryValue, @"png");
+}
+
+@end
+
+@implementation NSURLComponents (ImageURLsTestCase)
+
+- (NSString *)imageUrlQueryValue
+{
+    return [self.queryItems filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"name == %@", @"imageUrl"]].firstObject.value;
+}
+
+- (NSString *)widthQueryValue
+{
+    return [self.queryItems filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"name == %@", @"width"]].firstObject.value;
+}
+
+- (NSString *)formatQueryValue
+{
+    return [self.queryItems filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"name == %@", @"format"]].firstObject.value;
+}
+
+@end

--- a/Tests/SRGDataProviderRequestsTests/ImageURLsTestCase.m
+++ b/Tests/SRGDataProviderRequestsTests/ImageURLsTestCase.m
@@ -174,6 +174,18 @@
     XCTAssertEqualObjects(components.formatQueryValue, @"png");
 }
 
+- (void)testProgramGuideImage
+{
+    NSString *urlString = @"https://il.srgssr.ch/images/https://il.srgssr.ch/image-service/dynamic/7ec4fb9e.svg/format/png";
+    NSURLComponents *components = [self componentsFromUrlString:urlString width:SRGImageWidth320];
+    
+    XCTAssertEqualObjects(components.host, @"il.srgssr.ch");
+    XCTAssertEqual([components.path rangeOfString:@"/images"].location, 0);
+    XCTAssertEqualObjects(components.imageUrlQueryValue, urlString);
+    XCTAssertEqualObjects(components.widthQueryValue, @"320");
+    XCTAssertEqualObjects(components.formatQueryValue, @"png");
+}
+
 @end
 
 @implementation NSURLComponents (ImageURLsTestCase)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -186,15 +186,15 @@ Please carefully read the [SRG Network getting started guide](https://github.com
 Images are returned as opaque `SRGImage` objects, for which `SRGDataProvider` offers instance methods to generate corresponding URLs, in Objective-C:
 
 ```objective-c
-- (nullable NSURL *)URLForImage:(nullable SRGImage *)image withWidth:(SRGImageWidth)width scaling:(SRGImageScaling)scaling;
-- (nullable NSURL *)URLForImage:(nullable SRGImage *)image withSize:(SRGImageSize)size scaling:(SRGImageScaling)scaling;
+- (nullable NSURL *)URLForImage:(nullable SRGImage *)image withWidth:(SRGImageWidth)width scalingService:(SRGImageScalingService)scalingService;
+- (nullable NSURL *)URLForImage:(nullable SRGImage *)image withSize:(SRGImageSize)size scalingService:(SRGImageScalingService)scalingService;
 ```
 
 and in Swift:
 
 ```swift
-func url(for image: SRGImage?, width: SRGImageWidth, scaling: SRGImageScaling) -> URL?
-func url(for image: SRGImage?, size: SRGImageSize, scaling: SRGImageScaling) -> URL? 
+func url(for image: SRGImage?, width: SRGImageWidth, scalingService: SRGImageScalingService) -> URL?
+func url(for image: SRGImage?, size: SRGImageSize, scalingService: SRGImageScalingService) -> URL? 
 ```
 
 The image API allows you to either generate images based on a finite set of widths (arbitrary widths are not supported) or on a set of semantic sizes (small, medium, large) which should fulfill most needs. Should these semantic sizes not match your needs you are always free to either request images based on some desired widths or to define your own set of semantic sizes.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -186,22 +186,20 @@ Please carefully read the [SRG Network getting started guide](https://github.com
 Images are returned as opaque `SRGImage` objects, for which `SRGDataProvider` offers instance methods to generate corresponding URLs, in Objective-C:
 
 ```objective-c
-- (nullable NSURL *)URLForImage:(nullable SRGImage *)image withWidth:(SRGImageWidth)width scalingService:(SRGImageScalingService)scalingService;
-- (nullable NSURL *)URLForImage:(nullable SRGImage *)image withSize:(SRGImageSize)size scalingService:(SRGImageScalingService)scalingService;
+- (nullable NSURL *)URLForImage:(nullable SRGImage *)image withWidth:(SRGImageWidth)width;
+- (nullable NSURL *)URLForImage:(nullable SRGImage *)image withSize:(SRGImageSize)size;
 ```
 
 and in Swift:
 
 ```swift
-func url(for image: SRGImage?, width: SRGImageWidth, scalingService: SRGImageScalingService) -> URL?
-func url(for image: SRGImage?, size: SRGImageSize, scalingService: SRGImageScalingService) -> URL? 
+func url(for image: SRGImage?, width: SRGImageWidth) -> URL?
+func url(for image: SRGImage?, size: SRGImageSize) -> URL? 
 ```
 
 The image API allows you to either generate images based on a finite set of widths (arbitrary widths are not supported) or on a set of semantic sizes (small, medium, large) which should fulfill most needs. Should these semantic sizes not match your needs you are always free to either request images based on some desired widths or to define your own set of semantic sizes.
 
 Dimensions for images of a given width can be retrieved using `SRGRecommendedImageWidth` and `SRGRecommendedImageCGSize`. This can sometimes be useful if your application precisely needs to adjust some frames based on the size somes images they may contain.
-
-Finally, several behaviors are available when scaling images, e.g. to preserve the aspect ratio or to fit an image within a frame with a 1:1 or 16:9 frame. Check `SRGImageScaling` for available options.
 
 ## Dates and times
 

--- a/docs/SERVICE_AVAILABILITY.md
+++ b/docs/SERVICE_AVAILABILITY.md
@@ -184,19 +184,15 @@ These services provide a way to access content from any business unit from any d
 
 ## Image scaling services
 
-By default, it uses the Business Unit scaling image service.
+Various image services exist. Only prefined width or size are available for scaling.
+
+By default, the business unit scaling image service is used, hosted on their domain. Those services are BUs dependant. The convention is `https:[BU].ch/[image path]/scale/width/[width]`.
 
 | Request | SRF | RTS | RSI | RTR | SWI |
 |:-- |:--:|:--:|:--:|:--:|:--:|
-| Video image with width | ✅ | ✅ | ⚠️* | ✅ | ✅ |
-| Video image with height | ✅ | ✅ | ❌| ✅ | ⚠️* |
-| Audio image with width | ✅ | ✅ | ⚠️* | ✅ | ❌ |
-| Audio image with height | ⚠️* | ✅ | ❌ | ⚠️* | ❌ |
+| Video image with width | ✅ | ✅ | ⚠️ | ✅ | ✅ |
+| Audio image with width | ✅ | ✅ | ⚠️ | ✅ | ❌ |
 
-\*⚠️ means that a service is supported, but might not return an image with the exact requested `SRGImageWidth` dimension.
+⚠️ means that a service is supported, but might not return an image with the exact requested `SRGImageWidth` dimension.
 
-Optionnaly, `SRGImageScalingServiceCentralized` allows to use the [centralized image service from Integration Layer](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service) with `SRGImageWidth`. Jpeg and png input format are supported.
-
-### Remark
-
-Scale image URL services are BUs dependant
+Optionnaly, the [centralzed image service](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service) can be used, hosted on the service.

--- a/docs/SERVICE_AVAILABILITY.md
+++ b/docs/SERVICE_AVAILABILITY.md
@@ -186,6 +186,6 @@ These services provide a way to access content from any business unit from any d
 
 Only predefined widths and sizes are available for scaling.
 
-The [PlaySRG image service](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service) is used for all image urls*.
+The [PlaySRG image service](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service) is used for all image URLs*.
 
 *An exception exists when the url host contains `rts.ch` and the url path contains `.image`. In this case, the business unit scaling image service is still used, using the convention of `https:[BU].ch/[image path]/scale/width/[width]`.

--- a/docs/SERVICE_AVAILABILITY.md
+++ b/docs/SERVICE_AVAILABILITY.md
@@ -188,4 +188,4 @@ Only predefined widths and sizes are available for scaling.
 
 The [PlaySRG image service](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service) is used for all image URLs*.
 
-*An exception exists when the url host contains `rts.ch` and the url path contains `.image`. In this case, the business unit scaling image service is still used, using the convention of `https:[BU].ch/[image path]/scale/width/[width]`.
+*Exception for RTS CMS image urls. See [#47](https://github.com/SRGSSR/srgdataprovider-apple/issues/47) for more details.

--- a/docs/SERVICE_AVAILABILITY.md
+++ b/docs/SERVICE_AVAILABILITY.md
@@ -182,17 +182,10 @@ These services provide a way to access content from any business unit from any d
 
 ⚠️ Pagination is supported, but with a limit of 50. Attempting to request larger page sizes will fail.
 
-## Image scaling services
+## Image scaling service
 
-Various image services exist. Only prefined width or size are available for scaling.
+Only prefined width or size are available for scaling.
 
-By default, the business unit scaling image service is used, hosted on their domain. Those services are BUs dependant. The convention is `https:[BU].ch/[image path]/scale/width/[width]`.
+The [PlaySRG image service](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service) is used for all image urls*.
 
-| Request | SRF | RTS | RSI | RTR | SWI |
-|:-- |:--:|:--:|:--:|:--:|:--:|
-| Video image with width | ✅ | ✅ | ⚠️ | ✅ | ✅ |
-| Audio image with width | ✅ | ✅ | ⚠️ | ✅ | ❌ |
-
-⚠️ means that a service is supported, but might not return an image with the exact requested `SRGImageWidth` dimension.
-
-Optionnaly, the [centralzed image service](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service) can be used, hosted on the service.
+*An exeption exixts when url host contains `rts.ch` and url path contains `.image`. In this case, the business unit scaling image service is used, using the convention of `https:[BU].ch/[image path]/scale/width/[width]`.

--- a/docs/SERVICE_AVAILABILITY.md
+++ b/docs/SERVICE_AVAILABILITY.md
@@ -193,9 +193,9 @@ By default, it uses the Business Unit scaling image service.
 | Audio image with width | ✅ | ✅ | ⚠️* | ✅ | ❌ |
 | Audio image with height | ⚠️* | ✅ | ❌ | ⚠️* | ❌ |
 
-\*⚠️ means that a service is supported, but might not return an image with the exact requested dimension.
+\*⚠️ means that a service is supported, but might not return an image with the exact requested `SRGImageWidth` dimension.
 
-Optionnaly, `SRGImageScalingServiceCentralized` the [centralized image service from Integration Layer](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service) can be used.
+Optionnaly, `SRGImageScalingServiceCentralized` allows to use the [centralized image service from Integration Layer](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service) with `SRGImageWidth`. Jpeg and png input format are supported.
 
 ### Remark
 

--- a/docs/SERVICE_AVAILABILITY.md
+++ b/docs/SERVICE_AVAILABILITY.md
@@ -195,7 +195,7 @@ By default, it uses the Business Unit scaling image service.
 
 \*⚠️ means that a service is supported, but might not return an image with the exact requested dimension.
 
-Optionnaly, the [centralized Integration Layer image service](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service) can be used.
+Optionnaly, `SRGImageScalingServiceCentralized` the [centralized image service from Integration Layer](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service) can be used.
 
 ### Remark
 

--- a/docs/SERVICE_AVAILABILITY.md
+++ b/docs/SERVICE_AVAILABILITY.md
@@ -184,14 +184,18 @@ These services provide a way to access content from any business unit from any d
 
 ## Image scaling services
 
-A ⚠️ means that a service is supported, but might not return an image with the exact requested dimension.
+By default, it uses the Business Unit scaling image service.
 
 | Request | SRF | RTS | RSI | RTR | SWI |
 |:-- |:--:|:--:|:--:|:--:|:--:|
-| Video image with width | ✅ | ✅ | ⚠️ | ✅ | ✅ |
-| Video image with height | ✅ | ✅ | ❌| ✅ | ⚠️ |
-| Audio image with width | ✅ | ✅ | ⚠️ | ✅ | ❌ |
-| Audio image with height | ⚠️ | ✅ | ❌ | ⚠️ | ❌ |
+| Video image with width | ✅ | ✅ | ⚠️* | ✅ | ✅ |
+| Video image with height | ✅ | ✅ | ❌| ✅ | ⚠️* |
+| Audio image with width | ✅ | ✅ | ⚠️* | ✅ | ❌ |
+| Audio image with height | ⚠️* | ✅ | ❌ | ⚠️* | ❌ |
+
+\*⚠️ means that a service is supported, but might not return an image with the exact requested dimension.
+
+Optionnaly, the [centralized Integration Layer image service](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service) can be used.
 
 ### Remark
 

--- a/docs/SERVICE_AVAILABILITY.md
+++ b/docs/SERVICE_AVAILABILITY.md
@@ -188,4 +188,4 @@ Only prefined width or size are available for scaling.
 
 The [PlaySRG image service](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service) is used for all image urls*.
 
-*An exeption exixts when url host contains `rts.ch` and url path contains `.image`. In this case, the business unit scaling image service is used, using the convention of `https:[BU].ch/[image path]/scale/width/[width]`.
+*An exception exists when the url host contains `rts.ch` and the url path contains `.image`. In this case, the business unit scaling image service is still used, using the convention of `https:[BU].ch/[image path]/scale/width/[width]`.

--- a/docs/SERVICE_AVAILABILITY.md
+++ b/docs/SERVICE_AVAILABILITY.md
@@ -184,7 +184,7 @@ These services provide a way to access content from any business unit from any d
 
 ## Image scaling service
 
-Only prefined width or size are available for scaling.
+Only predefined widths and sizes are available for scaling.
 
 The [PlaySRG image service](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service) is used for all image urls*.
 


### PR DESCRIPTION
### Motivation and Context

Integration Layer product has deprecated endpoints, which will be removed during migration to the new major version (named SAM): [Services to transform images](http://www.srfcdn.ch/developer-docs/integrationlayer/api/public/swagger/index.html#/Image).

In addition:
- SRF business unit image service will remove the scaling support in 2023 Q4.
- RTS business unit image service does not work as expected with PlaySRG image service, regarding the aspect ratio given within the url. Will be fix in 2023 Q3.

The `ImageServices` has to be updated accordingly.

Main new image service to use is the [PlaySRG image service](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service).

### Description

- Remove all "aspectRatio" scaling options.
- ~~Introduce `SRGScalingService` to use business unit scaling services or the centralized Integration Layer one.~~
- Use PlaySRG image service by default, expect for `rts.ch` host with `.image` in the path, which still use the BU image service. See https://github.com/SRGSSR/srgdataprovider-apple/issues/47
- Update Unit tests with expected 16:9 ratio.
- Update Get Started and Service Availability documentations.
- Breaking changes API: New major version.

### Checklist

- [x] The branch should be rebased onto the `develop` branch for whole tests.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.