### PR TITLE
Fix unit test for not found urns

### DIFF
--- a/Tests/SRGDataProviderNetworkTests/CommonServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/CommonServicesTestCase.m
@@ -19,7 +19,7 @@ static NSString * const kTVShowSRFOtherURN = @"urn:srf:show:tv:c38cc259-b5cd-4ac
 
 static NSString * const kRadioShowSRFURN = @"urn:srf:show:radio:da260da8-2efd-49b0-9e7b-977f5f254f0d";
 
-static NSString * const kShowRTSURN = @"urn:rts:show:tv:6454706";
+static NSString * const kShowRTSURN = @"urn:rts:show:tv:548307";
 
 static NSString * const kTopicURN = @"urn:rts:topic:tv:1081";
 static NSString * const kInvalidTopicURN = @"urn:srf:topic:tv:1";

--- a/Tests/SRGDataProviderNetworkTests/DataProviderNetworkTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/DataProviderNetworkTestCase.m
@@ -513,7 +513,7 @@ static BOOL DataProviderURLContainsQueryParameter(NSURL *URL, NSString *name, NS
     dataProvider.globalParameters = @{ @"forceLocation" : @"WW" };
     
     __block SRGFirstPageRequest *request = nil;
-    request = [[dataProvider latestEpisodesForShowWithURN:@"urn:rts:show:tv:6454706" maximumPublicationDay:nil completionBlock:^(SRGEpisodeComposition * _Nullable episodeComposition, SRGPage * _Nonnull page, SRGPage * _Nullable nextPage, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+    request = [[dataProvider latestEpisodesForShowWithURN:@"urn:rts:show:tv:548307" maximumPublicationDay:nil completionBlock:^(SRGEpisodeComposition * _Nullable episodeComposition, SRGPage * _Nonnull page, SRGPage * _Nullable nextPage, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         if (page.number == 0) {
             SRGPageRequest *nextRequest = [request requestWithPage:nextPage];
             NSURLRequest *nextPageURLRequest = nextRequest.URLRequest;

--- a/Tests/SRGDataProviderNetworkTests/DataProviderNetworkTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/DataProviderNetworkTestCase.m
@@ -279,7 +279,7 @@ static BOOL DataProviderURLContainsQueryParameter(NSURL *URL, NSString *name, NS
     
     SRGDataProvider *dataProvider = [[SRGDataProvider alloc] initWithServiceURL:SRGIntegrationLayerProductionServiceURL()];
     __block SRGFirstPageRequest *request = nil;
-    request = [[dataProvider latestEpisodesForShowWithURN:@"urn:rts:show:tv:6454717" maximumPublicationDay:nil completionBlock:^(SRGEpisodeComposition * _Nullable episodeComposition, SRGPage * _Nonnull page, SRGPage * _Nullable nextPage, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+    request = [[dataProvider latestEpisodesForShowWithURN:@"urn:rts:show:tv:548307" maximumPublicationDay:nil completionBlock:^(SRGEpisodeComposition * _Nullable episodeComposition, SRGPage * _Nonnull page, SRGPage * _Nullable nextPage, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         XCTAssertEqual(episodeComposition.episodes.count, 4);
         
         if (page.number == 0) {

--- a/Tests/SRGDataProviderNetworkTests/RSIServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RSIServicesTestCase.m
@@ -10,7 +10,7 @@
 @import libextobjc;
 
 static NSString * const kAudioSearchQuery = @"tennis";
-static NSString * const kAudioURN = @"urn:rsi:audio:8800213";
+static NSString * const kAudioURN = @"urn:rsi:audio:16016821";
 
 static NSString * const kRadioChannelUid = @"rete-uno";
 static NSString * const kRadioLivestreamUid = @"livestream_ReteUno";
@@ -22,10 +22,10 @@ static NSString * const kTVChannelUid = @"la1";
 static NSString * const kTVLivestreamUid = @"livestream_La1";
 static NSString * const kTVShowSearchQuery = @"telegiornale";
 
-static NSString * const kTVShowURN = @"urn:rsi:show:tv:3567604";
-static NSString * const kTVShowOtherURN = @"urn:rsi:show:tv:8925532";
-static NSString * const kRadioShowURN = @"urn:rsi:show:radio:2100980";
-static NSString * const kRadioShowOtherURN = @"urn:rsi:show:radio:3519646";
+static NSString * const kTVShowURN = @"urn:rsi:show:tv:703571";
+static NSString * const kTVShowOtherURN = @"urn:rsi:show:tv:704146";
+static NSString * const kRadioShowURN = @"urn:rsi:show:radio:703560";
+static NSString * const kRadioShowOtherURN = @"urn:rsi:show:radio:1864030";
 static NSString * const kInvalidShowURN = @"urn:rsi:show:tv:999999999999999";
 static NSString * const kInvalidShowOtherURN = @"urn:srf:show:tv:999999999999999";
 
@@ -972,8 +972,8 @@ static NSString * const kUserId = @"test_user_id";
     XCTestExpectation *expectation1 = [self expectationWithDescription:@"Request succeeded"];
     
     // Full-length VOD
-    [[self.dataProvider mediaCompositionForURN:@"urn:rsi:video:9014650" standalone:NO withCompletionBlock:^(SRGMediaComposition * _Nullable mediaComposition, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertEqualObjects(mediaComposition.fullLengthMedia.uid, @"9014650");
+    [[self.dataProvider mediaCompositionForURN:@"urn:rsi:video:1391801" standalone:NO withCompletionBlock:^(SRGMediaComposition * _Nullable mediaComposition, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertEqualObjects(mediaComposition.fullLengthMedia.uid, @"1391801");
         [expectation1 fulfill];
     }] resume];
     
@@ -982,8 +982,8 @@ static NSString * const kUserId = @"test_user_id";
     // VOD segment
     XCTestExpectation *expectation2 = [self expectationWithDescription:@"Request succeeded"];
     
-    [[self.dataProvider mediaCompositionForURN:@"urn:rsi:video:9014449" standalone:NO withCompletionBlock:^(SRGMediaComposition * _Nullable mediaComposition, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertEqualObjects(mediaComposition.fullLengthMedia.uid, @"9014650");
+    [[self.dataProvider mediaCompositionForURN:@"urn:rsi:video:1011766" standalone:NO withCompletionBlock:^(SRGMediaComposition * _Nullable mediaComposition, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertEqualObjects(mediaComposition.fullLengthMedia.uid, @"1391801");
         [expectation2 fulfill];
     }] resume];
     
@@ -1012,8 +1012,8 @@ static NSString * const kUserId = @"test_user_id";
     // AOD clip
     XCTestExpectation *expectation5 = [self expectationWithDescription:@"Request succeeded"];
     
-    [[self.dataProvider mediaCompositionForURN:@"urn:rsi:audio:8923771" standalone:NO withCompletionBlock:^(SRGMediaComposition * _Nullable mediaComposition, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertEqualObjects(mediaComposition.fullLengthMedia.uid, @"8923771");
+    [[self.dataProvider mediaCompositionForURN:@"urn:rsi:audio:15844840" standalone:NO withCompletionBlock:^(SRGMediaComposition * _Nullable mediaComposition, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertEqualObjects(mediaComposition.fullLengthMedia.uid, @"15844840");
         [expectation5 fulfill];
     }] resume];
     

--- a/Tests/SRGDataProviderNetworkTests/RSIServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RSIServicesTestCase.m
@@ -510,13 +510,13 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-// Not supported for RSI
 - (void)testRadioTopics
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
     [[self.dataProvider radioTopicsForVendor:SRGVendorRSI withCompletionBlock:^(NSArray<SRGTopic *> * _Nullable topics, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
+        XCTAssertNotNil(topics);
+        XCTAssertNil(error);
         [expectation fulfill];
     }] resume];
     

--- a/Tests/SRGDataProviderNetworkTests/RTSServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RTSServicesTestCase.m
@@ -22,8 +22,8 @@ static NSString * const kTVChannelUid = @"143932a79bb5a123a646b68b1d1188d7ae493e
 static NSString * const kTVLivestreamUid = @"3608506";
 static NSString * const kTVShowSearchQuery = @"entendeur";
 
-static NSString * const kTVShowURN = @"urn:rts:show:tv:6454717";
-static NSString * const kTVShowOtherURN = @"urn:rts:show:tv:6454706";
+static NSString * const kTVShowURN = @"urn:rts:show:tv:548307";
+static NSString * const kTVShowOtherURN = @"urn:rts:show:tv:105932";
 static NSString * const kRadioShowURN = @"urn:rts:show:radio:8272976";
 static NSString * const kRadioShowOtherURN = @"urn:rts:show:radio:8841537";
 static NSString * const kInvalidShowURN = @"urn:rts:show:tv:999999999999999";

--- a/docs/SERVICE_AVAILABILITY.md
+++ b/docs/SERVICE_AVAILABILITY.md
@@ -89,7 +89,7 @@ Regional livestreams only exist for SRF, otherwise only main livestreams are ava
 
 | Request | SRF | RTS | RSI | RTR | SWI | Pagination | Unlimited page size |
 |:-- |:--:|:--:|:--:|:--:|:--:|:--:|:--:|
-| Topics | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | N/A |
+| Topics | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | N/A |
 
 ### Shows
 


### PR DESCRIPTION
### Motivation and Context

Fix unit / integration tests after:
- New RSI backend changed some media content ids.
- RTS database cleaning.

### Description

Update unknown show urns which returns `404`.

- All tv show tests in `RTSServicesTestCase`.
- All show and media tests in `RSIServicesTestCase`.
- `testBackgroundThreadCompletion`.
- In common services tests.

### Checklist

- [x] The branch should be rebased onto the `develop` branch for whole tests with nighties.
- [x] The documentation has been updated (if relevant).
- [x] The demo has been updated (if relevant).
- [x] Issues are linked to the PR, if any.