### PR TITLE
Use RTS CMS image urls with Play SRG image service

### DIFF
--- a/Sources/SRGDataProviderRequests/SRGDataProvider+ImageURLs.m
+++ b/Sources/SRGDataProviderRequests/SRGDataProvider+ImageURLs.m
@@ -32,13 +32,7 @@
         return imageURL;
     }
     
-    // See https://github.com/SRGSSR/srgdataprovider-apple/issues/47
-    if ([imageURL.host containsString:@"rts.ch"] && [imageURL.path containsString:@".image"]) {
-        return [self businessUnitScalingServiceURLForImageURL:imageURL width:width];
-    }
-    else {
-        return [self playsrgScalingServiceURLForImageURL:imageURL width:width];
-    }
+    return [self playsrgScalingServiceURLForImageURL:imageURL width:width];
 }
 
 - (NSURL *)requestURLForImageURL:(NSURL *)imageURL withSize:(SRGImageSize)size variant:(SRGImageVariant)variant
@@ -73,14 +67,6 @@
         [NSURLQueryItem queryItemWithName:@"width" value:@(width).stringValue]
     ];
     return URLComponents.URL;
-}
-
-#pragma mark Business Unit image scaling service
-
-- (NSURL *)businessUnitScalingServiceURLForImageURL:(NSURL *)imageURL width:(SRGImageWidth)width
-{
-    NSString *sizeComponent = [NSString stringWithFormat:@"scale/width/%@", @(width)];
-    return [imageURL URLByAppendingPathComponent:sizeComponent];
 }
 
 @end

--- a/Tests/SRGDataProviderRequestsTests/ImageURLsTestCase.m
+++ b/Tests/SRGDataProviderRequestsTests/ImageURLsTestCase.m
@@ -97,10 +97,11 @@
     NSString *urlString = @"https://www.rts.ch/2017/03/20/20/17/8478254.image/16x9";
     NSURLComponents *components = [self componentsFromUrlString:urlString width:SRGImageWidth320];
     
-    // Business unit image service
-    XCTAssertEqualObjects(components.host, @"www.rts.ch");
-    XCTAssertEqual([components.string rangeOfString:urlString].location, 0);
-    XCTAssertNotEqual([components.path rangeOfString:@"/scale/width/320"].location, NSNotFound);
+    XCTAssertEqualObjects(components.host, @"il.srgssr.ch");
+    XCTAssertEqual([components.path rangeOfString:@"/images"].location, 0);
+    XCTAssertEqualObjects(components.imageUrlQueryValue, urlString);
+    XCTAssertEqualObjects(components.widthQueryValue, @"320");
+    XCTAssertEqualObjects(components.formatQueryValue, @"jpg");
 }
 
 - (void)testAudioRTSImage
@@ -108,10 +109,11 @@
     NSString *urlString = @"https://www.rts.ch/2021/04/30/14/43/7978319.image/16x9";
     NSURLComponents *components = [self componentsFromUrlString:urlString width:SRGImageWidth320];
     
-    // Business unit image service
-    XCTAssertEqualObjects(components.host, @"www.rts.ch");
-    XCTAssertEqual([components.string rangeOfString:urlString].location, 0);
-    XCTAssertNotEqual([components.path rangeOfString:@"/scale/width/320"].location, NSNotFound);
+    XCTAssertEqualObjects(components.host, @"il.srgssr.ch");
+    XCTAssertEqual([components.path rangeOfString:@"/images"].location, 0);
+    XCTAssertEqualObjects(components.imageUrlQueryValue, urlString);
+    XCTAssertEqualObjects(components.widthQueryValue, @"320");
+    XCTAssertEqualObjects(components.formatQueryValue, @"jpg");;
 }
 
 - (void)testVideoSRFImage

--- a/docs/SERVICE_AVAILABILITY.md
+++ b/docs/SERVICE_AVAILABILITY.md
@@ -189,6 +189,4 @@ These services provide a way to access content from any business unit from any d
 
 Only predefined widths and sizes are available for scaling.
 
-The [PlaySRG image service](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service) is used for all image URLs*.
-
-*Exception for RTS CMS image urls. See [#47](https://github.com/SRGSSR/srgdataprovider-apple/issues/47) for more details.
+The [PlaySRG image service](https://confluence.srg.beecollaboration.com/display/SRGPLAY/Project+-+Image+Service) is used for all image URLs.


### PR DESCRIPTION
### Motivation and Context

See #47. RTS image service is now updated.

### Description

- All image urls use Play SRG image service, RTS image included.