### PR TITLE
Fix unit test for audio livestream

### DIFF
--- a/Tests/SRGDataProviderNetworkTests/ChapterTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/ChapterTestCase.m
@@ -190,12 +190,12 @@ static NSURL *ServiceTestURL(void)
     SRGDataProvider *dataProvider = [[SRGDataProvider alloc] initWithServiceURL:ServiceTestURL()];
     [[dataProvider mediaCompositionForURN:@"urn:rts:audio:3262320" standalone:NO withCompletionBlock:^(SRGMediaComposition * _Nullable mediaComposition, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         SRGChapter *mainChapter = mediaComposition.mainChapter;
-        XCTAssertEqual(mainChapter.resources.count, 1);
-        XCTAssertEqual(mainChapter.playableResources.count, 1);
+        XCTAssertEqual(mainChapter.resources.count, 2);
+        XCTAssertEqual(mainChapter.playableResources.count, 2);
         XCTAssertEqual([mainChapter resourcesForStreamingMethod:SRGStreamingMethodHLS].count, 1);
         XCTAssertEqual([mainChapter resourcesForStreamingMethod:SRGStreamingMethodHDS].count, 0);
         XCTAssertEqual([mainChapter resourcesForStreamingMethod:SRGStreamingMethodRTMP].count, 0);
-        XCTAssertEqual([mainChapter resourcesForStreamingMethod:SRGStreamingMethodProgressive].count, 0);
+        XCTAssertEqual([mainChapter resourcesForStreamingMethod:SRGStreamingMethodProgressive].count, 1);
         XCTAssertEqual(mainChapter.recommendedStreamingMethod, SRGStreamingMethodHLS);
         XCTAssertEqual(mainChapter.recommendedSubtitleFormat, SRGSubtitleFormatNone);
         [expectation fulfill];


### PR DESCRIPTION
### Motivation and Context

Fix unit / integration tests after:
- New  stream url request for HbbTV.

### Description

Update audio livestream test in `ChapterTestCase`. the livestream contains now a progressive stream url.

- All tv show tests in `RTSServicesTestCase`.
- All show and media tests in `RSIServicesTestCase`.
- `testBackgroundThreadCompletion`.
- In common services tests.

### Checklist

- [x] The branch should be rebased onto the `develop` branch for whole tests with nighties.
- [x] The documentation has been updated (if relevant).
- [x] The demo has been updated (if relevant).
- [x] Issues are linked to the PR, if any.