### PR TITLE
Additional content page properties

### DIFF
--- a/Sources/SRGDataProviderModel/SRGContentPage.m
+++ b/Sources/SRGDataProviderModel/SRGContentPage.m
@@ -14,6 +14,7 @@
 
 @property (nonatomic, copy) NSString *uid;
 @property (nonatomic) SRGVendor vendor;
+@property (nonatomic) SRGContentPageType type;
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) NSString *summary;
 @property (nonatomic, getter=isPublished) BOOL published;
@@ -34,6 +35,7 @@
         s_mapping = @{
             @keypath(SRGContentPage.new, uid) : @"id",
             @keypath(SRGContentPage.new, vendor) : @"vendor",
+            @keypath(SRGContentPage.new, type) : @"type",
             @keypath(SRGContentPage.new, title) : @"title",
             @keypath(SRGContentPage.new, summary) : @"description",
             @keypath(SRGContentPage.new, published) : @"isPublished",
@@ -49,6 +51,11 @@
 + (NSValueTransformer *)vendorJSONTransformer
 {
     return SRGVendorJSONTransformer();
+}
+
++ (NSValueTransformer *)typeJSONTransformer
+{
+    return SRGContentPageTypeJSONTransformer();
 }
 
 + (NSValueTransformer *)sectionsJSONTransformer

--- a/Sources/SRGDataProviderModel/SRGContentPage.m
+++ b/Sources/SRGDataProviderModel/SRGContentPage.m
@@ -15,6 +15,7 @@
 @property (nonatomic, copy) NSString *uid;
 @property (nonatomic) SRGVendor vendor;
 @property (nonatomic, copy) NSString *title;
+@property (nonatomic, copy) NSString *summary;
 @property (nonatomic, getter=isPublished) BOOL published;
 @property (nonatomic, copy) NSString *topicURN;
 @property (nonatomic) NSArray<SRGContentSection *> *sections;
@@ -34,6 +35,7 @@
             @keypath(SRGContentPage.new, uid) : @"id",
             @keypath(SRGContentPage.new, vendor) : @"vendor",
             @keypath(SRGContentPage.new, title) : @"title",
+            @keypath(SRGContentPage.new, summary) : @"description",
             @keypath(SRGContentPage.new, published) : @"isPublished",
             @keypath(SRGContentPage.new, topicURN) : @"topicUrn",
             @keypath(SRGContentPage.new, sections) : @"sectionList"

--- a/Sources/SRGDataProviderModel/SRGJSONTransformers.h
+++ b/Sources/SRGDataProviderModel/SRGJSONTransformers.h
@@ -14,6 +14,7 @@ OBJC_EXPORT NSValueTransformer *SRGAudioCodecJSONTransformer(void);
 OBJC_EXPORT NSValueTransformer *SRGBooleanInversionJSONTransformer(void);
 OBJC_EXPORT NSValueTransformer *SRGBlockingReasonJSONTransformer(void);
 OBJC_EXPORT NSValueTransformer *SRGContentSectionTypeJSONTransformer(void);
+OBJC_EXPORT NSValueTransformer *SRGContentPageTypeJSONTransformer(void);
 OBJC_EXPORT NSValueTransformer *SRGContentPresentationTypeJSONTransformer(void);
 OBJC_EXPORT NSValueTransformer *SRGContentTypeJSONTransformer(void);
 OBJC_EXPORT NSValueTransformer *SRGDRMTypeJSONTransformer(void);

--- a/Sources/SRGDataProviderModel/SRGJSONTransformers.m
+++ b/Sources/SRGDataProviderModel/SRGJSONTransformers.m
@@ -101,6 +101,22 @@ NSValueTransformer *SRGContentSectionTypeJSONTransformer(void)
     return s_transformer;
 }
 
+NSValueTransformer *SRGContentPageTypeJSONTransformer(void)
+{
+    static NSValueTransformer *s_transformer;
+    static dispatch_once_t s_onceToken;
+    dispatch_once(&s_onceToken, ^{
+        s_transformer = [NSValueTransformer mtl_valueMappingTransformerWithDictionary:@{ @"LANDING_PAGE" : @(SRGContentPageTypeLandingPage),
+                                                                                         @"TOPIC_PAGE" : @(SRGContentPageTypeTopicPage),
+                                                                                         @"SHOW_PAGE" : @(SRGContentPageTypeShowPage),
+                                                                                         @"DEFAULT_SHOW_PAGE" : @(SRGContentPageTypeDefaultShowPage),
+                                                                                         @"MICRO_PAGE": @(SRGContentPageTypeMicroPage) }
+                                                                         defaultValue:@(SRGContentPageTypeNone)
+                                                                  reverseDefaultValue:nil];
+    });
+    return s_transformer;
+}
+
 NSValueTransformer *SRGContentPresentationTypeJSONTransformer(void)
 {
     static NSValueTransformer *s_transformer;

--- a/Sources/SRGDataProviderModel/include/SRGContentPage.h
+++ b/Sources/SRGDataProviderModel/include/SRGContentPage.h
@@ -26,6 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) SRGVendor vendor;
 
 /**
+ *  The page type.
+ */
+@property (nonatomic, readonly) SRGContentPageType type;
+
+/**
  *  The page title.
  */
 @property (nonatomic, readonly, copy) NSString *title;

--- a/Sources/SRGDataProviderModel/include/SRGContentPage.h
+++ b/Sources/SRGDataProviderModel/include/SRGContentPage.h
@@ -31,6 +31,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, copy) NSString *title;
 
 /**
+ *  The page description.
+ */
+@property (nonatomic, readonly, copy, nullable) NSString *summary;
+
+/**
  *  `YES` iff the page has been published.
  */
 @property (nonatomic, readonly, getter=isPublished) BOOL published;

--- a/Sources/SRGDataProviderModel/include/SRGTypes.h
+++ b/Sources/SRGDataProviderModel/include/SRGTypes.h
@@ -90,6 +90,36 @@ typedef NS_CLOSED_ENUM(NSInteger, SRGBlockingReason) {
 };
 
 /**
+ *  Content page types.
+ */
+typedef NS_CLOSED_ENUM(NSInteger, SRGContentPageType) {
+    /**
+     *  Not specified.
+     */
+    SRGContentPageTypeNone = 0,
+    /**
+     *  Landing page.
+     */
+    SRGContentPageTypeLandingPage,
+    /**
+     *  Topic page.
+     */
+    SRGContentPageTypeTopicPage,
+    /**
+     *  Show page.
+     */
+    SRGContentPageTypeShowPage,
+    /**
+     *  Default show page.
+     */
+    SRGContentPageTypeDefaultShowPage,
+    /**
+     *  Micro page.
+     */
+    SRGContentPageTypeMicroPage
+};
+
+/**
  *  Content presentation types.
  */
 typedef NS_CLOSED_ENUM(NSInteger, SRGContentPresentationType) {

--- a/Tests/SRGDataProviderNetworkTests/ContentServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/ContentServicesTestCase.m
@@ -181,10 +181,10 @@
     [self contentPageForMicroPagePublished:NO];
 }
 
--(void)contentPageForMicroPagePublished:(BOOL)published
+- (void)contentPageForMicroPagePublished:(BOOL)published
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
-
+    
     [[self.dataProvider contentPageForVendor:SRGVendorRTS uid:@"56b3f3d2-10f0-49f7-b3f4-0892096cde30" published:published atDate:nil withCompletionBlock:^(SRGContentPage * _Nullable contentPage, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         XCTAssertNotNil(contentPage);
         XCTAssertEqual(contentPage.type, SRGContentPageTypeMicroPage);
@@ -192,7 +192,7 @@
         XCTAssertNil(error);
         [expectation fulfill];
     }] resume];
-
+    
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 

--- a/Tests/SRGDataProviderNetworkTests/ContentServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/ContentServicesTestCase.m
@@ -35,6 +35,7 @@
     
     [[self.dataProvider contentPageForVendor:SRGVendorRTS uid:@"40d9e6dd-00ac-4b84-98b8-3fa66cfe2df3" published:YES atDate:nil withCompletionBlock:^(SRGContentPage * _Nullable contentPage, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         XCTAssertNotNil(contentPage);
+        XCTAssertEqual(contentPage.type, SRGContentPageTypeLandingPage);
         XCTAssertNil(error);
         [expectation1 fulfill];
     }] resume];
@@ -45,6 +46,7 @@
     
     [[self.dataProvider contentPageForVendor:SRGVendorRTS uid:@"40d9e6dd-00ac-4b84-98b8-3fa66cfe2df3" published:NO atDate:nil withCompletionBlock:^(SRGContentPage * _Nullable contentPage, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         XCTAssertNotNil(contentPage);
+        XCTAssertEqual(contentPage.type, SRGContentPageTypeLandingPage);
         XCTAssertNil(error);
         [expectation2 fulfill];
     }] resume];
@@ -101,6 +103,7 @@
     
     [[self.dataProvider contentPageForVendor:SRGVendorSRF topicWithURN:@"urn:srf:topic:tv:a709c610-b275-4c0c-a496-cba304c36712" published:YES atDate:nil withCompletionBlock:^(SRGContentPage * _Nullable contentPage, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         XCTAssertNotNil(contentPage);
+        XCTAssertEqual(contentPage.type, SRGContentPageTypeTopicPage);
         XCTAssertNil(error);
         [expectation1 fulfill];
     }] resume];
@@ -111,6 +114,7 @@
     
     [[self.dataProvider contentPageForVendor:SRGVendorSRF topicWithURN:@"urn:srf:topic:tv:a709c610-b275-4c0c-a496-cba304c36712" published:NO atDate:nil withCompletionBlock:^(SRGContentPage * _Nullable contentPage, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         XCTAssertNotNil(contentPage);
+        XCTAssertEqual(contentPage.type, SRGContentPageTypeTopicPage);
         XCTAssertNil(error);
         [expectation2 fulfill];
     }] resume];
@@ -166,6 +170,33 @@
         XCTAssertNotNil(contentPage);
         XCTAssertNil(error);
         [expectation5 fulfill];
+    }] resume];
+    
+    [self waitForExpectationsWithTimeout:30. handler:nil];
+}
+
+- (void)testContentPageForMicroPage
+{
+    XCTestExpectation *expectation1 = [self expectationWithDescription:@"Request succeeded"];
+    
+    [[self.dataProvider contentPageForVendor:SRGVendorRTS uid:@"56b3f3d2-10f0-49f7-b3f4-0892096cde30" published:YES atDate:nil withCompletionBlock:^(SRGContentPage * _Nullable contentPage, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertNotNil(contentPage);
+        XCTAssertEqual(contentPage.type, SRGContentPageTypeMicroPage);
+        XCTAssertNotNil(contentPage.summary);
+        XCTAssertNil(error);
+        [expectation1 fulfill];
+    }] resume];
+    
+    [self waitForExpectationsWithTimeout:30. handler:nil];
+    
+    XCTestExpectation *expectation2 = [self expectationWithDescription:@"Request succeeded"];
+    
+    [[self.dataProvider contentPageForVendor:SRGVendorRTS uid:@"56b3f3d2-10f0-49f7-b3f4-0892096cde30" published:NO atDate:nil withCompletionBlock:^(SRGContentPage * _Nullable contentPage, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        XCTAssertNotNil(contentPage);
+        XCTAssertEqual(contentPage.type, SRGContentPageTypeMicroPage);
+        XCTAssertNotNil(contentPage.summary);
+        XCTAssertNil(error);
+        [expectation2 fulfill];
     }] resume];
     
     [self waitForExpectationsWithTimeout:30. handler:nil];

--- a/Tests/SRGDataProviderNetworkTests/ContentServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/ContentServicesTestCase.m
@@ -177,28 +177,22 @@
 
 - (void)testContentPageForMicroPage
 {
-    XCTestExpectation *expectation1 = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider contentPageForVendor:SRGVendorRTS uid:@"56b3f3d2-10f0-49f7-b3f4-0892096cde30" published:YES atDate:nil withCompletionBlock:^(SRGContentPage * _Nullable contentPage, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+    [self contentPageForMicroPagePublished:YES];
+    [self contentPageForMicroPagePublished:NO];
+}
+
+-(void)contentPageForMicroPagePublished:(BOOL)published
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
+
+    [[self.dataProvider contentPageForVendor:SRGVendorRTS uid:@"56b3f3d2-10f0-49f7-b3f4-0892096cde30" published:published atDate:nil withCompletionBlock:^(SRGContentPage * _Nullable contentPage, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         XCTAssertNotNil(contentPage);
         XCTAssertEqual(contentPage.type, SRGContentPageTypeMicroPage);
         XCTAssertNotNil(contentPage.summary);
         XCTAssertNil(error);
-        [expectation1 fulfill];
+        [expectation fulfill];
     }] resume];
-    
-    [self waitForExpectationsWithTimeout:30. handler:nil];
-    
-    XCTestExpectation *expectation2 = [self expectationWithDescription:@"Request succeeded"];
-    
-    [[self.dataProvider contentPageForVendor:SRGVendorRTS uid:@"56b3f3d2-10f0-49f7-b3f4-0892096cde30" published:NO atDate:nil withCompletionBlock:^(SRGContentPage * _Nullable contentPage, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(contentPage);
-        XCTAssertEqual(contentPage.type, SRGContentPageTypeMicroPage);
-        XCTAssertNotNil(contentPage.summary);
-        XCTAssertNil(error);
-        [expectation2 fulfill];
-    }] resume];
-    
+
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 


### PR DESCRIPTION
### Motivation and Context

To support content marketing micro pages from PAC CMS:
- additional summary property is needed.
- additional content page type property is needed.

http://www.srfcdn.ch/developer-docs/integrationlayer/api/public/swagger/index.html#/Page/Page

### Description

- Add `summary` optional string property to `SRGContentPage`.
- Add `type` enum property as `SRGContentPageType` to `SRGContentPage`.
- Update tests cases.

### Checklist

- [x] The branch should be rebased onto the `develop` branch for whole tests with nighties.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.