### PR TITLE
Fix RTS radio topic list unit test

### DIFF
--- a/Tests/SRGDataProviderNetworkTests/RTSServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RTSServicesTestCase.m
@@ -541,13 +541,13 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-// Not supported for RTS
 - (void)testRadioTopics
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
     [[self.dataProvider radioTopicsForVendor:SRGVendorRTS withCompletionBlock:^(NSArray<SRGTopic *> * _Nullable topics, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
+        XCTAssertNotNil(topics);
+        XCTAssertNil(error);
         [expectation fulfill];
     }] resume];
     

--- a/docs/SERVICE_AVAILABILITY.md
+++ b/docs/SERVICE_AVAILABILITY.md
@@ -90,7 +90,7 @@ Regional livestreams only exist for SRF, otherwise only main livestreams are ava
 
 | Request | SRF | RTS | RSI | RTR | SWI | Pagination | Unlimited page size |
 |:-- |:--:|:--:|:--:|:--:|:--:|:--:|:--:|
-| Topics | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | N/A |
+| Topics | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | N/A |
 
 ### Shows
 


### PR DESCRIPTION
### Motivation and Context

Fix unit / integration tests after:
- RTS topic migration to the new SAM (SRG asset metadata) backend.
- Similar to #50 with RSI.

### Description

Update unknown show urns which returns `404`.

- Update `RTSServicesTestCase`.
- Update documentation.

### Checklist

- [x] The branch should be rebased onto the `develop` branch for whole tests with nighties.
- [x] The documentation has been updated (if relevant).
- [x] The demo has been updated (if relevant).
- [x] Issues are linked to the PR, if any.