### PR TITLE
Fix RTS show with topics test

### DIFF
--- a/Tests/SRGDataProviderNetworkTests/RTSServicesTestCase.m
+++ b/Tests/SRGDataProviderNetworkTests/RTSServicesTestCase.m
@@ -1174,14 +1174,14 @@ static NSString * const kUserId = @"test_user_id";
     [self waitForExpectationsWithTimeout:30. handler:nil];
 }
 
-// Not supported for RTS
 - (void)testShowWithTopics
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Request succeeded"];
     
     [[self.dataProvider showWithURN:kTVShowURN completionBlock:^(SRGShow * _Nullable show, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
         XCTAssertNotNil(show);
-        XCTAssertNil(show.topics);
+        XCTAssertNotNil(show.topics);
+        XCTAssertTrue(show.topics.count > 0);
         [expectation fulfill];
     }] resume];
     


### PR DESCRIPTION
### Motivation and Context

Fix unit / integration tests after:
- RTS show migration to the new SAM (SRG asset metadata) backend.

### Description

Update show with topics test which now can check that topic list is not empty.

- Update `RTSServicesTestCase`.

### Checklist

- [x] The branch should be rebased onto the `develop` branch for whole tests with nighties.
- [x] The documentation has been updated (if relevant).
- [x] The demo has been updated (if relevant).
- [x] Issues are linked to the PR, if any.