### PR TITLE
Add podcast image variant

### DIFF
--- a/Sources/SRGDataProviderModel/SRGShow.m
+++ b/Sources/SRGDataProviderModel/SRGShow.m
@@ -101,7 +101,7 @@
 
 - (SRGImage *)podcastImage
 {
-    return [SRGImage imageWithURL:self.podcastImageURL variant:SRGImageVariantDefault];
+    return [SRGImage imageWithURL:self.podcastImageURL variant:SRGImageVariantPodcast];
 }
 
 #pragma mark Transformers

--- a/Sources/SRGDataProviderModel/SRGTypes.m
+++ b/Sources/SRGDataProviderModel/SRGTypes.m
@@ -43,11 +43,30 @@ static SRGImageWidth SRGPosterImageWidthForSize(SRGImageSize size)
     return s_widths[@(size)].integerValue;
 }
 
+static SRGImageWidth SRGPodcastImageWidthForSize(SRGImageSize size)
+{
+    static NSDictionary<NSNumber *, NSNumber *> *s_widths;
+    static dispatch_once_t s_onceToken;
+    dispatch_once(&s_onceToken, ^{
+        s_widths = @{
+            @(SRGImageSizeSmall) : @(SRGImageWidth320),
+            @(SRGImageSizeMedium) : @(SRGImageWidth480),
+            @(SRGImageSizeLarge) : @(SRGImageWidth960)
+        };
+    });
+    return s_widths[@(size)].integerValue;
+}
+
 SRGImageWidth SRGRecommendedImageWidth(SRGImageSize size, SRGImageVariant variant)
 {
     switch (variant) {
         case SRGImageVariantPoster: {
             return SRGPosterImageWidthForSize(size);
+            break;
+        }
+            
+        case SRGImageVariantPodcast: {
+            return SRGPodcastImageWidthForSize(size);
             break;
         }
             
@@ -64,6 +83,12 @@ CGSize SRGRecommendedImageCGSize(SRGImageSize size, SRGImageVariant variant)
         case SRGImageVariantPoster: {
             CGFloat width = SRGPosterImageWidthForSize(size);
             return CGSizeMake(width, width * 3.f / 2.f);
+            break;
+        }
+            
+        case SRGImageVariantPodcast: {
+            CGFloat width = SRGPodcastImageWidthForSize(size);
+            return CGSizeMake(width, width);
             break;
         }
             

--- a/Sources/SRGDataProviderModel/include/SRGTypes.h
+++ b/Sources/SRGDataProviderModel/include/SRGTypes.h
@@ -716,7 +716,8 @@ typedef NS_CLOSED_ENUM(NSInteger, SRGImageSize) {
  */
 typedef NS_CLOSED_ENUM(NSInteger, SRGImageVariant) {
     SRGImageVariantDefault = 0,
-    SRGImageVariantPoster
+    SRGImageVariantPoster,
+    SRGImageVariantPodcast
 };
 
 /**


### PR DESCRIPTION
## Description

The `SRGShow` IL object has various image urls. One is a square image, called `podcastImage`. 

The PR propose to add this image variant, related to this image, like `SRGImageVariantPoster` exists for `SRGShow.posterImage`.

## Changes Made

- Add `SRGImageVariantPodcast` to `SRGImageVariant` enum.
- Update associated functions which use this enum.
- Use this variant for `SRGShow.podcastImage`.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.