### PR TITLE
Attach current locale to default calendar

### DIFF
--- a/Sources/SRGDataProviderModel/NSCalendar+SRGDataProvider.m
+++ b/Sources/SRGDataProviderModel/NSCalendar+SRGDataProvider.m
@@ -13,6 +13,7 @@
 + (NSCalendar *)srg_defaultCalendar
 {
     NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    calendar.locale = NSLocale.currentLocale;
     calendar.timeZone = NSTimeZone.srg_defaultTimeZone;
     return calendar;
 }

--- a/Tests/SRGDataProviderModelTests/CalendarTestCase.m
+++ b/Tests/SRGDataProviderModelTests/CalendarTestCase.m
@@ -1,0 +1,28 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@import SRGDataProviderModel;
+@import XCTest;
+
+@interface CalendarTestCase : XCTestCase
+
+@end
+
+@implementation CalendarTestCase
+
+- (void)testLocale
+{
+    NSCalendar *calendar = NSCalendar.srg_defaultCalendar;
+    XCTAssertEqualObjects(calendar.locale, NSLocale.currentLocale);
+}
+
+- (void)testTimezone
+{
+    NSCalendar *calendar = NSCalendar.srg_defaultCalendar;
+    XCTAssertEqualObjects(calendar.timeZone.name, @"Europe/Zurich");
+}
+
+@end


### PR DESCRIPTION
# Description

This PR fixes an issue with the default calendar, preventing some device settings associated with the locale from being correctly applied (e.g. the first weekday).

# Changes made

Self-explanatory.