### PR TITLE
PLAYNEXT-1271 - Parse bools in NSNumber to allow them to be nullable

### DIFF
--- a/Sources/SRGDataProviderModel/SRGShow.m
+++ b/Sources/SRGDataProviderModel/SRGShow.m
@@ -38,8 +38,8 @@
 @property (nonatomic) SRGTransmission transmission;
 @property (nonatomic) SRGVendor vendor;
 @property (nonatomic) SRGBroadcastInformation *broadcastInformation;
-@property (nonatomic) BOOL shouldFallbackToPosterImage;
-@property (nonatomic) BOOL shouldFallbackToPodcastImage;
+@property (nonatomic) NSNumber *shouldFallbackToPosterImage;
+@property (nonatomic) NSNumber *shouldFallbackToPodcastImage;
 
 @end
 

--- a/Sources/SRGDataProviderModel/include/SRGShow.h
+++ b/Sources/SRGDataProviderModel/include/SRGShow.h
@@ -87,12 +87,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Whether to use posterImage as a fallback URL
  */
-@property (nonatomic, readonly) BOOL shouldFallbackToPosterImage;
+@property (nonatomic, readonly, nullable) NSNumber *shouldFallbackToPosterImage;
 
 /**
  *  Whether to use podcastImage as a fallback URL
  */
-@property (nonatomic, readonly) BOOL shouldFallbackToPodcastImage;
+@property (nonatomic, readonly, nullable) NSNumber *shouldFallbackToPodcastImage;
 
 
 @end


### PR DESCRIPTION
This is small but needed improvement since not having the value in the IL is not falsy and causes issues down the line.